### PR TITLE
Change glob

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import slugify from "@utils/slugify";
 import type { Frontmatter } from "src/types";
 import Socials from "@components/Socials.astro";
 
-const posts = await Astro.glob<Frontmatter>("../contents/*.md");
+const posts = await Astro.glob<Frontmatter>("../contents/**/*.md");
 
 const sortedPosts = getSortedPosts(posts);
 ---

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -28,7 +28,7 @@ type PagePaths = {
 }[];
 
 export async function getStaticPaths() {
-  const posts = await Astro.glob<Frontmatter>("../../contents/*.md");
+  const posts = await Astro.glob<Frontmatter>("../../contents/**/*.md");
 
   let postResult: PostResult = posts.map((post) => {
     return {
@@ -51,7 +51,7 @@ export async function getStaticPaths() {
 const { slug } = Astro.params;
 const { post } = Astro.props;
 
-const posts = await Astro.glob<Frontmatter>("../../contents/*.md");
+const posts = await Astro.glob<Frontmatter>("../../contents/**/*.md");
 
 const sortedPosts = getSortedPosts(posts);
 

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -5,7 +5,7 @@ import getSortedPosts from "@utils/getSortedPosts";
 import getPageNumbers from "@utils/getPageNumbers";
 import type { Frontmatter } from "src/types";
 
-const posts = await Astro.glob<Frontmatter>("../../contents/*.md");
+const posts = await Astro.glob<Frontmatter>("../../contents/**/*.md");
 
 const sortedPosts = getSortedPosts(posts);
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -5,7 +5,7 @@ import type { MarkdownInstance } from "astro";
 import slugify from "@utils/slugify";
 
 const postImportResult = import.meta.glob<MarkdownInstance<Frontmatter>>(
-  "../contents/*.md",
+  "../contents/**/**/*.md",
   {
     eager: true,
   }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -8,7 +8,7 @@ import Search from "@components/Search";
 import type { Frontmatter } from "src/types";
 
 // Retrieve all articles
-const posts = await Astro.glob<Frontmatter>("../contents/*.md");
+const posts = await Astro.glob<Frontmatter>("../contents/**/*.md");
 
 // List of items to search in
 const searchList = posts

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -18,7 +18,7 @@ export interface Props {
 
 export async function getStaticPaths() {
   const posts: MarkdownInstance<Frontmatter>[] = await Astro.glob(
-    "../../contents/*.md"
+    "../../contents/**/*.md"
   );
 
   const tags = getUniqueTags(posts);
@@ -38,7 +38,7 @@ export async function getStaticPaths() {
 const { tag } = Astro.props;
 
 const posts: MarkdownInstance<Frontmatter>[] = await Astro.glob(
-  "../../contents/*.md"
+  "../../contents/**/*.md"
 );
 
 const tagPosts = getPostsByTag(posts, tag);

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -8,7 +8,7 @@ import Tag from "@components/Tag.astro";
 import getUniqueTags from "@utils/getUniqueTags";
 import type { Frontmatter } from "src/types";
 
-const posts = await Astro.glob<Frontmatter>("../../contents/*.md");
+const posts = await Astro.glob<Frontmatter>("../../contents/**/*.md");
 
 let tags = getUniqueTags(posts);
 ---


### PR DESCRIPTION
This PR changes the glob patterns used to find `.md` files,  by doing this, you can still have:
```
contents
   ├── post1.md
   └── post2.md
```
But can also add subfolders to have your files sorted in a better way, eg:
```
contents
   ├── post1.md
   ├── post2.md
   ├── folder1
   │     └── post3.md
   └── folder2
           └── folder3
                   └── post4.md
 ```