### PR TITLE
fix: should be 0 results not result

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -97,9 +97,9 @@ export default function SearchBar({ searchList }: Props) {
       {inputVal.length > 1 && (
         <div className="mt-8">
           Found {searchResults?.length}
-          {searchResults?.length && searchResults?.length > 1
-            ? " results"
-            : " result"}{" "}
+          {searchResults?.length && searchResults?.length === 1
+            ? " result"
+            : " results"}{" "}
           for '{inputVal}'
         </div>
       )}


### PR DESCRIPTION

<img width="531" alt="image" src="https://user-images.githubusercontent.com/95541290/204726388-8c537848-8d5e-402f-9399-1f4c23fe6dc5.png">

When there no results for a query, it should say 0 ***results*** not 0 ***result***. This PR fixes this problem.