### PR TITLE
Disallow unknown keys with .strict()

### DIFF
--- a/src/content/_schemas.ts
+++ b/src/content/_schemas.ts
@@ -1,15 +1,17 @@
 import { z } from "astro:content";
 
-export const blogSchema = z.object({
-  author: z.string().optional(),
-  pubDatetime: z.date(),
-  title: z.string(),
-  postSlug: z.string().optional(),
-  featured: z.boolean().optional(),
-  draft: z.boolean().optional(),
-  tags: z.array(z.string()).default(["others"]),
-  ogImage: z.string().optional(),
-  description: z.string(),
-});
+export const blogSchema = z
+  .object({
+    author: z.string().optional(),
+    pubDatetime: z.date(),
+    title: z.string(),
+    postSlug: z.string().optional(),
+    featured: z.boolean().optional(),
+    draft: z.boolean().optional(),
+    tags: z.array(z.string()).default(["others"]),
+    ogImage: z.string().optional(),
+    description: z.string(),
+  })
+  .strict();
 
 export type BlogFrontmatter = z.infer<typeof blogSchema>;


### PR DESCRIPTION
https://zod.dev/?id=strict

If schema(s) are made with strict, it will disallow extra keys in the markdown frontmatter.