### PR TITLE
(lint-staged) Fix prettier error 'No parser could be inferred for file' using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "lint-staged": {
     "*": [
-      "prettier --write"
+      "prettier --plugin-search-dir=. --write"
     ]
   }
 }


### PR DESCRIPTION
Using pnpm as package manager, when commit an Astro template, prettier throw the error 'No parser could be inferred for file: ...'.

To reproduce you can create a new branch, install the packages with `pnpm install`, modify an Astro template (ex. src/pages/index.astro) and try to commit.

Adding the parameter `--plugin-search-dir=.` to prettier command in `lint-staged` section of `package.json` solved the problem for me. I found the solution in this [comment](https://github.com/withastro/prettier-plugin-astro/issues/97#issuecomment-1013645333) for more details.
