### PR TITLE
fix: build error astro@2.1.4 && update astro@2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@astrojs/rss": "^2.3.0",
     "@resvg/resvg-js": "^2.4.1",
-    "astro": "^2.1.3",
+    "astro": "^2.1.5",
     "fuse.js": "^6.6.2",
     "github-slugger": "^2.0.0",
     "remark-collapse": "^0.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,17 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {
-      "@*": ["./src/*"]
+      "@assets/*": ["assets/*"],
+      "@config": ["config.ts"],
+      "@components/*": ["components/*"],
+      "@content/*": ["content/*"],
+      "@layouts/*": ["layouts/*"],
+      "@pages/*": ["pages/*"],
+      "@scripts/*": ["scripts/*"],
+      "@styles/*": ["styles/*"],
+      "@utils/*": ["utils/*"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "@content/*": ["content/*"],
       "@layouts/*": ["layouts/*"],
       "@pages/*": ["pages/*"],
-      "@scripts/*": ["scripts/*"],
       "@styles/*": ["styles/*"],
       "@utils/*": ["utils/*"]
     }


### PR DESCRIPTION
Hello, 

from issue #48 . I have the same issue after updating astro to 2.1.4

and I have fixed it by updating the tsconfig file

It seems like the new astro@2.1.4 was trying to call react from the wrong path.
