### PR TITLE
Fix: slugify tags in post detail page

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -5,6 +5,7 @@ import Footer from "@components/Footer.astro";
 import Tag from "@components/Tag.astro";
 import Datetime from "@components/Datetime";
 import type { CollectionEntry } from "astro:content";
+import { slugifyStr } from "@utils/slugify";
 
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -12,7 +13,8 @@ export interface Props {
 
 const { post } = Astro.props;
 
-const { title, author, description, ogImage, pubDatetime, tags } = post.data;
+let { title, author, description, ogImage, pubDatetime, tags } = post.data;
+tags = tags.map(tag => slugifyStr(tag));
 
 const { Content } = await post.render();
 


### PR DESCRIPTION
Hello,

unslugified tags in post detail page seem to cause some problems:

1. Inconsistent display of the same tag on different pages.
2. Direct to a 404 page from an existing tag.

![01](https://user-images.githubusercontent.com/42985789/235444628-e7a2266c-3e93-4286-8f55-2ede2ed5765c.png)

I have fixed it by modifying the frontmatter of `PostDetails.astro`.