### PR TITLE
fix: tailwind jsdoc for intellisense

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,3 @@
-/** @type {import('tailwindcss').Config} */
-
 function withOpacity(variableName) {
   return ({ opacityValue }) => {
     if (opacityValue !== undefined) {
@@ -9,6 +7,7 @@ function withOpacity(variableName) {
   };
 }
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {


### PR DESCRIPTION
- Fixes tailwind config's JSDOC placement. Without this change IDE intellisense does not work. 

Broken in 02d29f09144db026db8cf26f424e3ca66f0cd225