### PR TITLE
Stop reinstantiating Fuse on keypress

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import Card from "@components/Card";
 import slugify from "@utils/slugify";
 import type { BlogFrontmatter } from "@content/_schemas";
@@ -30,12 +30,16 @@ export default function SearchBar({ searchList }: Props) {
     setInputVal(e.currentTarget.value);
   };
 
-  const fuse = new Fuse(searchList, {
-    keys: ["title", "description"],
-    includeMatches: true,
-    minMatchCharLength: 2,
-    threshold: 0.5,
-  });
+  const fuse = useMemo(
+    () =>
+      new Fuse(searchList, {
+        keys: ["title", "description"],
+        includeMatches: true,
+        minMatchCharLength: 2,
+        threshold: 0.5,
+      }),
+    [searchList]
+  );
 
   useEffect(() => {
     // if URL has search query,


### PR DESCRIPTION
Memoising the value of `fuse` based off of the search list to prevent reinstantiating it on search keypress.

`searchList` will never change, so this will reduce work needed to do while searching big post lists.