### PR TITLE
Refactor: getUniqueTags should perform conversions exactly once per tag

### DIFF
--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -2,16 +2,14 @@ import { slugifyStr } from "./slugify";
 import type { CollectionEntry } from "astro:content";
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-  let tags: string[] = [];
   const filteredPosts = posts.filter(({ data }) => !data.draft);
-  filteredPosts.forEach(post => {
-    tags = [...tags, ...post.data.tags]
-      .map(tag => slugifyStr(tag))
-      .filter(
-        (value: string, index: number, self: string[]) =>
-          self.indexOf(value) === index
-      );
-  });
+  const tags: string[] = filteredPosts
+    .flatMap(post => post.data.tags)
+    .map(tag => slugifyStr(tag))
+    .filter(
+      (value: string, index: number, self: string[]) =>
+        self.indexOf(value) === index
+    );
   return tags;
 };
 

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -9,7 +9,8 @@ const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
     .filter(
       (value: string, index: number, self: string[]) =>
         self.indexOf(value) === index
-    );
+    )
+    .sort((tagA: string, tagB: string) => tagA.localeCompare(tagB));
   return tags;
 };
 


### PR DESCRIPTION
Previously, the `forEach` loop was spreading the tags list and updating it on every iteration. So for every post, the slugify operation was happening on previously converted data again.

Similarly, the last filter operation to remove duplicates was repeated for every post ($`O(n\log{}n)`$) instead of checking once at the end ($`O(n)`$).

Additional suggestion: Removing duplicates can be better handled by using [`lodash.uniq`](https://lodash.com/docs/3.10.1#uniq) or [`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)