### PR TITLE
build: fix WebSocket error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "private": false,
   "scripts": {
-    "dev": "astro check --watch & astro dev",
+    "dev": "astro check --watch && astro dev",
     "start": "astro dev",
     "build": "astro build && jampack ./dist",
     "preview": "astro preview",


### PR DESCRIPTION
Without two & symbols, you get a "WebSocket server error: Port is already in use" 
Adding this will remove this error.

Closed #72