### PR TITLE
fix(css): text wrap in code blocks

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -114,6 +114,11 @@
   ::-webkit-scrollbar-thumb:hover {
     @apply bg-skin-card-muted;
   }
+
+  code {
+    white-space: pre;
+    overflow: scroll;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
This patch fixes the text wrapping that happens on mobile view. When the code starts wrapping it becomes harder to read it.

| Before | After |
|--------|-------|
| ![before](https://github.com/satnaing/astro-paper/assets/43862225/fddca551-708a-457c-af06-79f656f25a22) | ![after](https://github.com/satnaing/astro-paper/assets/43862225/5ffb872b-aa61-4fff-8c1a-625b904651e3) |

I applied a few styles to the global `code` tag on the `base.css` file.

- `white-space: pre` 👈 "Sequences of white space are preserved. Lines are only broken at newline characters in the source and at br elements." - [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space)
- `overflow: scroll` 👈 "Overflow content is clipped at the element's padding box, and overflow content can be scrolled into view using scroll bars." - [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)

Please let me know what do you think.