### PR TITLE
fix single line code block wrapping issue

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -115,9 +115,12 @@
     @apply bg-skin-card-muted;
   }
 
-  code {
+  code, blockquote {
+    word-wrap: break-word;
+  }
+
+  pre > code {
     white-space: pre;
-    overflow: scroll;
   }
 }
 


### PR DESCRIPTION
white-space should be pre-wrap - or else, a single long line of code block may break the layout of whole page on mobile devices 
![378257479_698057215472898_6310478035160498106_n](https://github.com/satnaing/astro-paper/assets/7238675/1f31c14e-e4c1-4238-8273-4599d2769072)
