### PR TITLE
fix single line code block wrapping issue

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -115,9 +115,12 @@
     @apply bg-skin-card-muted;
   }
 
-  code {
+  code, blockquote {
+    word-wrap: break-word;
+  }
+
+  pre > code {
     white-space: pre;
-    overflow: scroll;
   }
 }
 


### PR DESCRIPTION
white-space should be pre-wrap - or else, a single long line of code block may break the layout of whole page on mobile devices

use word break for code and blockquote, white-space: pre for fenced code