### PR TITLE
feat: dynamically generate robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-User-agent: Googlebot
-Disallow: /nogooglebot/
-
-User-agent: *
-Allow: /

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from "astro";
+import { SITE } from "@config";
+
+const robots = `
+User-agent: Googlebot
+Disallow: /nogooglebot/
+
+User-agent: *
+Allow: /
+
+Sitemap: ${new URL("sitemap-index.xml", SITE.website).href}
+`.trim();
+
+export const GET: APIRoute = () =>
+  new Response(robots, {
+    headers: { "Content-Type": "text/plain" },
+  });


### PR DESCRIPTION
Adds sitemap URL to robots.txt, This way it follows the guidelines given by both astro-sitemap [docs](https://docs.astro.build/en/guides/integrations-guide/sitemap/#usage) and google recommendation.