### PR TITLE
fix(remarkToc): fix a mismatch in the types

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   ],
   markdown: {
     remarkPlugins: [
-      remarkToc,
+      remarkToc(),
       [
         remarkCollapse,
         {


### PR DESCRIPTION
The issue you're encountering is a type error in your TypeScript code. It seems that there is an incompatibility between the types being used in your code. Specifically, the error message indicates that there is a mismatch in the types of various properties and functions.