### PR TITLE
fix: solve modDatetime type errors

### DIFF
--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -2,7 +2,7 @@ import { LOCALE } from "@config";
 
 interface DatetimesProps {
   pubDatetime: string | Date;
-  modDatetime: string | Date | undefined;
+  modDatetime: string | Date | undefined | null;
 }
 
 interface Props extends DatetimesProps {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ export interface Props {
   ogImage?: string;
   canonicalURL?: string;
   pubDatetime?: Date;
-  modDatetime?: Date;
+  modDatetime?: Date | null;
   scrollSmooth?: boolean;
 }
 


### PR DESCRIPTION
Update modDatetime props type to have null type for components that have modDatetime as props.