### PR TITLE
fix: include <li> block inside if statement

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -89,9 +89,9 @@ const { activeNav } = Astro.props;
               <span class="sr-only">Search</span>
             </LinkButton>
           </li>
-          <li>
-            {
-              SITE.lightAndDarkMode && (
+          {
+            SITE.lightAndDarkMode && (
+              <li>
                 <button
                   id="theme-btn"
                   class="focus-outline"
@@ -106,9 +106,9 @@ const { activeNav } = Astro.props;
                     <path d="M6.993 12c0 2.761 2.246 5.007 5.007 5.007s5.007-2.246 5.007-5.007S14.761 6.993 12 6.993 6.993 9.239 6.993 12zM12 8.993c1.658 0 3.007 1.349 3.007 3.007S13.658 15.007 12 15.007 8.993 13.658 8.993 12 10.342 8.993 12 8.993zM10.998 19h2v3h-2zm0-17h2v3h-2zm-9 9h3v2h-3zm17 0h3v2h-3zM4.219 18.363l2.12-2.122 1.415 1.414-2.12 2.122zM16.24 6.344l2.122-2.122 1.414 1.414-2.122 2.122zM6.342 7.759 4.22 5.637l1.415-1.414 2.12 2.122zm13.434 10.605-1.414 1.414-2.122-2.122 1.414-1.414z" />
                   </svg>
                 </button>
-              )
-            }
-          </li>
+              </li>
+            )
+          }
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
This removes the extra "right-padding" inside the header search icon when `lightAndDarkMode` is `false` so UI is consistent.

![Screenshot_2024-01-12_11 57 45](https://github.com/satnaing/astro-paper/assets/66087392/58038c88-5f7c-4123-97db-79ec60846c0a)
![Screenshot_2024-01-12_11 58 03](https://github.com/satnaing/astro-paper/assets/66087392/e53dde3b-bb4a-4298-81a1-719722b4d346)
