### PR TITLE
feat: add heading links to PostDetails

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -106,6 +106,22 @@ const layoutProps = {
 </style>
 
 <script is:inline>
+  /** Attaches links to headings in the document,
+   *  allowing sharing of sections easily */
+  function addHeadingLinks() {
+    let headings = Array.from(document.querySelectorAll("h2, h3, h4, h5, h6"));
+    for (let heading of headings) {
+      heading.classList.add("group")
+      let link = document.createElement("a");
+      link.innerText = "#";
+      link.className = "heading-link hidden group-hover:inline-block ml-2";
+      link.href = "#" + heading.id;
+      link.ariaHidden = true;
+      heading.appendChild(link);
+    }
+  }
+  addHeadingLinks();
+
   /** Attaches copy buttons to code blocks in the document,
    * allowing users to copy code easily. */
   function attachCopyButtons() {


### PR DESCRIPTION
Implemented easy links to headings (h2-h6) on post details.
The links are aria-hidden and only show on hover.
I was going to set this up for my own blog so I thought I'd share in case you want to include this in Astro Paper.
 
![Heading on hover](https://github.com/satnaing/astro-paper/assets/63359209/8a7457c4-08db-4263-808b-17fb28cab5b7)
![Link on hover](https://github.com/satnaing/astro-paper/assets/63359209/f8ab3d2a-21c8-4f06-852d-70f5117f6f33)
