### PR TITLE
fix: disable margin bottom on image

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -66,7 +66,7 @@
     prose-table:text-skin-base prose-th:border
     prose-th:border-skin-line prose-td:border 
     prose-td:border-skin-line prose-img:mx-auto 
-    prose-img:!mt-2 prose-img:border-2 
+    prose-img:!mt-2 prose-img:!mb-2 prose-img:border-2 
     prose-img:border-skin-line prose-hr:!border-skin-line;
   }
   .prose a {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -65,8 +65,8 @@
     prose-ul:overflow-x-clip prose-ul:!text-skin-base prose-li:marker:!text-skin-accent
     prose-table:text-skin-base prose-th:border
     prose-th:border-skin-line prose-td:border 
-    prose-td:border-skin-line prose-img:mx-auto 
-    prose-img:!mt-2 prose-img:!mb-2 prose-img:border-2 
+    prose-td:border-skin-line prose-img:!my-2 
+    prose-img:mx-auto prose-img:border-2 
     prose-img:border-skin-line prose-hr:!border-skin-line;
   }
   .prose a {


### PR DESCRIPTION
The result is better on images with caption defined as: 
```
![alt text](/path/to/img)
*caption*
```