### PR TITLE
fix: reduce H2 margin top

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -66,6 +66,9 @@ module.exports = {
             code: {
               color: false,
             },
+            'h2': {
+              marginTop: '1em',
+            },
           },
         },
       },


### PR DESCRIPTION
Space above H2 title is too large, reduces it from `2em` to `1em`