### PR TITLE
fix: update back button to redirect to home when no route history

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -50,7 +50,7 @@ const layoutProps = {
   <div class="mx-auto flex w-full max-w-3xl justify-start px-2">
     <button
       class="focus-outline mb-2 mt-8 flex hover:opacity-75"
-      onclick="history.back()"
+      onclick="(() => (history.length === 1) ? window.location = '/' : history.back())()"
     >
       <svg xmlns="http://www.w3.org/2000/svg"
         ><path
@@ -111,7 +111,7 @@ const layoutProps = {
   function addHeadingLinks() {
     let headings = Array.from(document.querySelectorAll("h2, h3, h4, h5, h6"));
     for (let heading of headings) {
-      heading.classList.add("group")
+      heading.classList.add("group");
       let link = document.createElement("a");
       link.innerText = "#";
       link.className = "heading-link hidden group-hover:inline-block ml-2";


### PR DESCRIPTION
**_Description_**

Update back button in PostDetails.astro to redirect to home page when there's no route history.
If a blog post url is pasted in the browser and there's no route history, prior to this commit, back button did not work as expected. Now, if there's somewhere to go back, the back button will go back to the previous route.
If not, the back button will redirect to home page.

**_Before_**

https://github.com/satnaing/astro-paper/assets/53733092/a4bfa96d-4d4b-4c39-b827-ce8072a0e1f5

**_After_**

https://github.com/satnaing/astro-paper/assets/53733092/098f6c0b-7e9b-4bd1-b032-92444063d9df

**_Tested Browsers_**
- Chrome ✅ (mobile/desktop)
- Safari ✅ (mobile/desktop)
- Opera ✅ (mobile/desktop)
- Firefox ✅
- Edge ✅