### PR TITLE
feat: syntax-highlighting dark/light themed

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -27,7 +27,10 @@ export default defineConfig({
       ],
     ],
     shikiConfig: {
-      theme: "one-dark-pro",
+      experimentalThemes: {
+        dark: "one-dark-pro",
+        light: "solarized-light",
+      },
       wrap: true,
     },
   },

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -133,3 +133,12 @@
     @apply outline-2 outline-offset-1 outline-skin-fill focus-visible:no-underline focus-visible:outline-dashed;
   }
 }
+
+html[data-theme="dark"] .astro-code,
+html[data-theme="dark"] .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}


### PR DESCRIPTION
When site theme is toggled, the syntax-highlighted code blocks stay dark themed. For a more consistent look and feel, I feel those code-blocks should switch theme as well. This PR

- configures dark and light syntax-highlight theme  in `astro.config.ts`
- adds css to set respective theme in dark mode, according to [docs](https://shikiji.netlify.app/guide/dual-themes)

`Solarized light` was arbitrarily chosen as light theme as its background-color is different from the site background.