### PR TITLE
Fix a small typo in predefined-color-schemes.md

### DIFF
--- a/src/content/blog/predefined-color-schemes.md
+++ b/src/content/blog/predefined-color-schemes.md
@@ -73,7 +73,7 @@ html[data-theme="light"] {
 
 ## Dark color schemes
 
-Light color scheme has to be defined as `html[data-theme="dark"]`.
+Dark color scheme has to be defined as `html[data-theme="dark"]`.
 
 ### AstroPaper 1 original Dark Theme
 


### PR DESCRIPTION
Seems to be missed whilst copy pasting the sentence. `Light` -> `Dark`