### PR TITLE
feat: add SITE.title in Post Title

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -7,6 +7,7 @@ import Datetime from "@components/Datetime";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
+import {SITE} from "../config";
 
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -34,7 +35,7 @@ const ogUrl = new URL(
 ).href;
 
 const layoutProps = {
-  title,
+  title: `${title} | ${SITE.title}`,
   author,
   description,
   pubDatetime,

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -7,7 +7,7 @@ import Datetime from "@components/Datetime";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
-import {SITE} from "../config";
+import { SITE } from "@config";
 
 export interface Props {
   post: CollectionEntry<"blog">;


### PR DESCRIPTION
Yeah, what you see is true. In the previous versions, the SITE.title was NOT added to the Post Title.

I fixed this issue in this PR.