### PR TITLE
refactor: Display "Update:" only if modDateTime more current than pubDateTime

### DIFF
--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -46,7 +46,11 @@ export default function Datetime({
 }
 
 const FormattedDatetime = ({ pubDatetime, modDatetime }: DatetimesProps) => {
-  const myDatetime = new Date(modDatetime ? modDatetime : pubDatetime);
+  const myDatetime = new Date(
+    (modDatetime ?? pubDatetime) > pubDatetime
+      ? modDatetime ?? pubDatetime
+      : pubDatetime
+  );
 
   const date = myDatetime.toLocaleDateString(LOCALE.langTag, {
     year: "numeric",

--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -28,7 +28,7 @@ export default function Datetime({
         <path d="M7 11h2v2H7zm0 4h2v2H7zm4-4h2v2h-2zm0 4h2v2h-2zm4-4h2v2h-2zm0 4h2v2h-2z"></path>
         <path d="M5 22h14c1.103 0 2-.897 2-2V6c0-1.103-.897-2-2-2h-2V2h-2v2H9V2H7v2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zM19 8l.001 12H5V8h14z"></path>
       </svg>
-      {modDatetime != null && modDatetime > pubDatetime ? (
+      {modDatetime && modDatetime > pubDatetime ? (
         <span className={`italic ${size === "sm" ? "text-sm" : "text-base"}`}>
           Updated:
         </span>
@@ -47,9 +47,7 @@ export default function Datetime({
 
 const FormattedDatetime = ({ pubDatetime, modDatetime }: DatetimesProps) => {
   const myDatetime = new Date(
-    (modDatetime ?? pubDatetime) > pubDatetime
-      ? modDatetime ?? pubDatetime
-      : pubDatetime
+    modDatetime && modDatetime > pubDatetime ? modDatetime : pubDatetime
   );
 
   const date = myDatetime.toLocaleDateString(LOCALE.langTag, {

--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -28,7 +28,7 @@ export default function Datetime({
         <path d="M7 11h2v2H7zm0 4h2v2H7zm4-4h2v2h-2zm0 4h2v2h-2zm4-4h2v2h-2zm0 4h2v2h-2z"></path>
         <path d="M5 22h14c1.103 0 2-.897 2-2V6c0-1.103-.897-2-2-2h-2V2h-2v2H9V2H7v2H5c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zM19 8l.001 12H5V8h14z"></path>
       </svg>
-      {modDatetime ? (
+      {modDatetime != null && modDatetime > pubDatetime ? (
         <span className={`italic ${size === "sm" ? "text-sm" : "text-base"}`}>
           Updated:
         </span>


### PR DESCRIPTION
Hello, I usually create a new post with FrontMatterCMS (vscode plugin) which creates both pubDateTime and modDateTime at the same time in a new post.

Then I noticed that. When the time of both parts is the same. The page will show the word "Update". I would like to change this to show the word "Update" only if modDateTime is more current than pubDateTime.

Thank you for creating this theme. Hopefully, this small change will be beneficial to you.