### PR TITLE
Add timezone offset in custom code snippets

### DIFF
--- a/.vscode/astro-paper.code-snippets
+++ b/.vscode/astro-paper.code-snippets
@@ -5,7 +5,7 @@
     "body": [
       "---",
       "author: $1",
-      "pubDatetime: $CURRENT_YEAR-$CURRENT_MONTH-${CURRENT_DATE}T$CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND.000Z",
+      "pubDatetime: $CURRENT_YEAR-$CURRENT_MONTH-${CURRENT_DATE}T$CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND.000$CURRENT_TIMEZONE_OFFSET",
       "modDatetime: $3",
       "title: $4",
       "featured: ${5|false,true|}",


### PR DESCRIPTION
Add `$CURRENT_TIMEZONE_OFFSET` in vscode code snippets to reflect real time.

VSCode docs: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables