### PR TITLE
fix: avoid `undefined` class-name in the `Datetime` component

### DIFF
--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -17,7 +17,9 @@ export default function Datetime({
   className,
 }: Props) {
   return (
-    <div className={`flex items-center space-x-2 opacity-80 ${className}`}>
+    <div
+      className={`flex items-center space-x-2 opacity-80 ${className ?? ""}`.trim()}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         className={`${


### PR DESCRIPTION
Avoid `undefined` when passing `className` as a prop

Is there a better solution for this project, such as using clsx to combine classes?

## Before

![image](https://github.com/satnaing/astro-paper/assets/26923823/0cb4cfa6-a499-4663-8218-f144593f9964)

## After

![image](https://github.com/satnaing/astro-paper/assets/26923823/37a0ab56-0de7-40f8-a553-3820584f3022)
