### PR TITLE
fix: avoid `undefined` when passing class-name as prop

### DIFF
--- a/src/components/Datetime.tsx
+++ b/src/components/Datetime.tsx
@@ -14,10 +14,12 @@ export default function Datetime({
   pubDatetime,
   modDatetime,
   size = "sm",
-  className,
+  className = "",
 }: Props) {
   return (
-    <div className={`flex items-center space-x-2 opacity-80 ${className}`}>
+    <div
+      className={`flex items-center space-x-2 opacity-80 ${className}`.trim()}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         className={`${

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -19,7 +19,7 @@ const {
 {
   disabled ? (
     <span
-      class={`group inline-block ${className}`.trim()}
+      class:list={["group inline-block", className]}
       aria-label={ariaLabel}
       title={title}
       aria-disabled={disabled}
@@ -29,7 +29,7 @@ const {
   ) : (
     <a
       {href}
-      class={`group inline-block hover:text-skin-accent ${className}`}
+      class:list={["group inline-block hover:text-skin-accent", className]}
       aria-label={ariaLabel}
       title={title}
     >

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -7,13 +7,19 @@ export interface Props {
   disabled?: boolean;
 }
 
-const { href, className, ariaLabel, title, disabled = false } = Astro.props;
+const {
+  href,
+  className = "",
+  ariaLabel,
+  title,
+  disabled = false,
+} = Astro.props;
 ---
 
 {
   disabled ? (
     <span
-      class={`group inline-block ${className}`}
+      class={`group inline-block ${className}`.trim()}
       aria-label={ariaLabel}
       title={title}
       aria-disabled={disabled}


### PR DESCRIPTION
## What

Avoid `undefined` when passing `className` as a prop, and trimming will remove any extra spacing.

## Before

![image](https://github.com/satnaing/astro-paper/assets/26923823/0cb4cfa6-a499-4663-8218-f144593f9964)

![image](https://github.com/satnaing/astro-paper/assets/26923823/bbd88bf7-a6a4-459e-b1c4-7e8372c88786)

## After

![image](https://github.com/satnaing/astro-paper/assets/26923823/37a0ab56-0de7-40f8-a553-3820584f3022)

![image](https://github.com/satnaing/astro-paper/assets/26923823/51746952-e97e-4a5d-9a98-fb75e7ff2c8a)

