### PR TITLE
chore: use `@typescript-eslint/parser` as the default parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     browser: true,
   },
   extends: ["eslint:recommended", "plugin:astro/recommended"],
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",


### PR DESCRIPTION
## What

Adding `parser: "@typescript-eslint/parser"` as the default parser allows ESLint to lint `*.(ts|tsx)` files.

## Before

I am adding an unused variable in `src/config.ts` leads to the expectation of receiving an error from the  [no-unused-vars](https://eslint.org/docs/latest/rules/no-unused-vars) rule in the output. However, ESLint fails to recognize the `import type` syntax.

```ts
import type { Site, SocialObjects } from "./types";

const foo = ""; // <-- unused variable

// skip
```

![image](https://github.com/satnaing/astro-paper/assets/26923823/d8cb420b-0ab8-4651-ab23-4b16d7c2407c)

## After

![image](https://github.com/satnaing/astro-paper/assets/26923823/169bedde-37c5-4b72-88fd-d617c10de9cd)

 improving DX in VS Code with the ESLint extension for better error detection.

![image](https://github.com/satnaing/astro-paper/assets/26923823/970a7585-1166-4ac0-9bfb-6ecb5a85d71f)

