### PR TITLE
feat: keyboard focusable heading links

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -157,11 +157,15 @@ const layoutProps = {
     let headings = Array.from(document.querySelectorAll("h2, h3, h4, h5, h6"));
     for (let heading of headings) {
       heading.classList.add("group");
-      let link = document.createElement("a");
-      link.innerText = "#";
-      link.className = "heading-link hidden group-hover:inline-block ml-2";
+      const link = document.createElement("a");
+      link.className =
+        "heading-link ml-2 opacity-0 group-hover:opacity-100 focus:opacity-100";
       link.href = "#" + heading.id;
-      link.ariaHidden = "true";
+
+      const span = document.createElement("span");
+      span.ariaHidden = "true";
+      span.innerText = "#";
+      link.appendChild(span);
       heading.appendChild(link);
     }
   }


### PR DESCRIPTION
## What

- Making the heading links focusable for navigation using a keyboard's tab button.
- Keeping the anchor link in the accessibility tree while hiding the "#" symbol for the screen reader.

## After

https://github.com/satnaing/astro-paper/assets/26923823/ef062564-8f9f-48ab-99d0-e881a599dd42

![image](https://github.com/satnaing/astro-paper/assets/26923823/4b60519e-3636-41df-826f-5c6f09ece16d)

