### PR TITLE
fix: the local development failed to load the `src/assets/` images

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "astro/config";
+import { defineConfig, passthroughImageService } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import react from "@astrojs/react";
 import remarkToc from "remark-toc";
@@ -37,4 +37,7 @@ export default defineConfig({
     },
   },
   scopedStyleStrategy: "where",
+  image: {
+    service: passthroughImageService(),
+  },
 });


### PR DESCRIPTION
Steps To Reproduce
- Run `astro dev`
- Markdown image path use **/src/assets/**
```md
![something](@assets/images/example.jpg)
<!-- OR -->
![something](../../assets/images/example.jpg)
```
- Fail to load the image

https://docs.astro.build/en/guides/images/#configure-no-op-passthrough-service