### PR TITLE
feat: include `h1` in link attachment script

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -151,12 +151,19 @@ const layoutProps = {
   }
   document.addEventListener("scroll", updateScrollProgress);
 
-  /** Attaches links to headings in the document,
+  /** Attaches links to headings in the article,
    *  allowing sharing of sections easily */
   function addHeadingLinks() {
-    let headings = Array.from(
-      document.querySelectorAll("h1, h2, h3, h4, h5, h6")
+    const article = document.getElementById("article");
+
+    if (article === null) {
+      throw new Error("Article element not found");
+    }
+
+    const headings = Array.from(
+      article.querySelectorAll("h1, h2, h3, h4, h5, h6")
     );
+
     for (let heading of headings) {
       heading.classList.add("group");
       let link = document.createElement("a");

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -154,7 +154,9 @@ const layoutProps = {
   /** Attaches links to headings in the document,
    *  allowing sharing of sections easily */
   function addHeadingLinks() {
-    let headings = Array.from(document.querySelectorAll("h2, h3, h4, h5, h6"));
+    let headings = Array.from(
+      document.querySelectorAll("h1, h2, h3, h4, h5, h6")
+    );
     for (let heading of headings) {
       heading.classList.add("group");
       let link = document.createElement("a");


### PR DESCRIPTION
Currently, `h1` is excluded but there is no clear reason to do so.

If the original intention was to exclude the post title (`h1`), it would be more appropriate to narrow the scope (i.e. `document` =>  `article`).

related PR:
- #232