### PR TITLE
fix: adding data-theme to tailwind config

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,6 +9,7 @@ function withOpacity(variableName) {
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ["selector", "[data-theme='dark']"],
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
     // Remove the following screen breakpoint or add other breakpoints


### PR DESCRIPTION
I had a similar issue using the `dark:` prefix. Ended up fixing it by adding the `darkMode` selector to the tailwind config. https://tailwindcss.com/docs/dark-mode

Fixes #288 

PS @satnaing, love this template!