### PR TITLE
refactor: remove redundant role

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -73,7 +73,7 @@ const layoutProps = {
       size="lg"
       className="my-2"
     />
-    <article id="article" role="article" class="prose mx-auto mt-8 max-w-3xl">
+    <article id="article" class="prose mx-auto mt-8 max-w-3xl">
       <Content />
     </article>
 


### PR DESCRIPTION
## What

The `<article>` tag already has an implicit role defined by the HTML specification, so we do not need to add an ARIA role attribute.

Reference:

- https://html-validate.org/rules/no-redundant-role.html
- https://web.dev/learn/accessibility/aria-html#aria_in_html

## Screenshot

After the change:

![image](https://github.com/user-attachments/assets/907a6a27-5c9b-439f-b9c3-9da5068e4dd4)






