### PR TITLE
fix: invalid json syntax in `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "@layouts/*": ["layouts/*"],
       "@pages/*": ["pages/*"],
       "@styles/*": ["styles/*"],
-      "@utils/*": ["utils/*"],
-    },
-  },
+      "@utils/*": ["utils/*"]
+    }
+  }
 }


### PR DESCRIPTION
Trailing comma is invalid json syntax. This makes some tools like `vim` breaks while opening this project.

https://github.com/vim/vim/blob/22105fd1fe0dcfe993b5c04c6ebe017a626116e3/runtime/ftplugin/astro.vim#L45-L61