### PR TITLE
docs: update pre-commit hook blog post

### DIFF
--- a/src/content/blog/setting-dates-via-git-hooks.md
+++ b/src/content/blog/setting-dates-via-git-hooks.md
@@ -24,6 +24,8 @@ You can get around this by having a `hooks` directory and manually copy them to 
 
 As this project uses npm, we are able to make use of a package called [Husky](https://typicode.github.io/husky/) (this is already installed in AstroPaper) to automatically install the hooks for us.
 
+> Update! In AstroPaper [v4.3.0](https://github.com/satnaing/astro-paper/releases/tag/v4.3.0), the pre-commit hook has been removed in favor of GitHub Actions. However, you can easily [install Husky](https://typicode.github.io/husky/get-started.html) yourself.
+
 ## The Hook
 
 As we want this hook to run as we commit the code to update the dates and then have that as part of our change we are going to use the `pre-commit` hook. This has already been set up by this AstroPaper project, but if it hadn't, you would run `npx husky add .husky/pre-commit 'echo "This is our new pre-commit hook"'`.


### PR DESCRIPTION
Add a section about the removal of the pre-commit
hook in v4.3.0.