### PR TITLE
fix(a11y): remove aria-labels from non-interactive elements

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -20,7 +20,6 @@ const {
   disabled ? (
     <span
       class:list={["group inline-block", className]}
-      aria-label={ariaLabel}
       title={title}
       aria-disabled={disabled}
     >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,7 +11,7 @@ import LinkButton from "@components/LinkButton.astro";
 
   <main id="main-content">
     <div class="not-found-wrapper">
-      <h1 aria-label="404 Not Found">404</h1>
+      <h1>404</h1>
       <span aria-hidden="true">¯\_(ツ)_/¯</span>
       <p>Page Not Found</p>
       <LinkButton


### PR DESCRIPTION
Remove aria-label from `<h1>` of 404 page and disabled LinkButton.

Resolves #263