### PR TITLE
fix(blog): correct file reference in reading time guide

### DIFF
--- a/src/content/blog/how-to-add-an-estimated-reading-time.md
+++ b/src/content/blog/how-to-add-an-estimated-reading-time.md
@@ -215,7 +215,7 @@ Step (2) Make sure to refactor every file which uses `getSortedPosts` function. 
 Files that use `getSortedPosts` function are as follow
 
 - src/pages/index.astro
-- src/pages/posts/index.astro
+- src/pages/search.astro
 - src/pages/rss.xml.ts
 - src/pages/posts/index.astro
 - src/pages/posts/[slug]/index.astro


### PR DESCRIPTION
i find inside `search.astro` also use `getSortedPosts`, and there is duplicated item on the list, i though that the duplicated one was supposed to be `search.astro`