### PR TITLE
fix(og): add the missing SITE.website to loadGoogleFonts 

### DIFF
--- a/src/utils/og-templates/site.tsx
+++ b/src/utils/og-templates/site.tsx
@@ -89,7 +89,9 @@ export default async () => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: (await loadGoogleFonts(SITE.title + SITE.desc + SITE.website)) as FontOptions[],
+      fonts: (await loadGoogleFonts(
+        SITE.title + SITE.desc + SITE.website
+      )) as FontOptions[],
     }
   );
 };

--- a/src/utils/og-templates/site.tsx
+++ b/src/utils/og-templates/site.tsx
@@ -89,7 +89,7 @@ export default async () => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: (await loadGoogleFonts(SITE.title + SITE.desc)) as FontOptions[],
+      fonts: (await loadGoogleFonts(SITE.title + SITE.desc + SITE.website)) as FontOptions[],
     }
   );
 };


### PR DESCRIPTION
Fix the issue where SITE.website cannot be rendered due to missing some font characters

![og](https://github.com/user-attachments/assets/3b80f0d0-d856-421a-a8e2-7a8a816b940f)