### PR TITLE
Render LaTeX

### DIFF
--- a/src/content/blog/how-to-add-latex-equations-in-blog-posts.md
+++ b/src/content/blog/how-to-add-latex-equations-in-blog-posts.md
@@ -15,15 +15,13 @@ This document demonstrates how to use LaTeX equations in your Markdown files for
 
 ## Instructions
 
-In this section, you will find instructions on how to add support for LaTeX in your Markdown files for AstroPaper. 
+In this section, you will find instructions on how to add support for LaTeX in your Markdown files for AstroPaper.
 
-1. Install the necessary dependencies by running `npm install rehype-katex remark-math katex`.
+1. Install the necessary remark and rehype plugins by running `npm install rehype-katex remark-math katex`.
 
-2. Update the Astro configuration to use the these libraries (see in **diff** format):
+2. Update the Astro configuration (`astro.config.ts`) to use the these plugins:
 
 ```ts
-// astro.config.ts
-
 // other imports
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -48,11 +46,9 @@ export default defineConfig({
 });
 ```
 
-3. Import KaTeX CSS in the main layout (see in **diff** format):
+3. Import KaTeX CSS in the main layout file `src/layouts/Layout.astro`
 
-```html
-// src/layouts/Layout.astro
-
+```astro
 ---
 import { LOCALE, SITE } from "@config";
 
@@ -60,27 +56,27 @@ import { LOCALE, SITE } from "@config";
 ---
 
 <!doctype html>
+<!-- others... -->
+<script is:inline src="/toggle-theme.js"></script>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css"
+/>
 
-// layout...
- 
-    <script is:inline src="/toggle-theme.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css">
-  </head>
-  <body>
-    <slot />
-  </body>
-</html>
+<body>
+  <slot />
+</body>
 ```
 
-And *voilà*, this setup allows you to write LaTeX equations in your Markdown files, which will be rendered properly when the site is built. Once you do it, the rest of the document will appear rendered correctly. 
+And _voilà_, this setup allows you to write LaTeX equations in your Markdown files, which will be rendered properly when the site is built. Once you do it, the rest of the document will appear rendered correctly.
 
 ## Inline Equations
 
 Inline equations are written between single dollar signs `$...$`. Here are some examples:
 
-1. The famous mass-energy equivalence formula: $E = mc^2$
-2. The quadratic formula: $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$
-3. Euler's identity: $e^{i\pi} + 1 = 0$
+1. The famous mass-energy equivalence formula: `$E = mc^2$`
+2. The quadratic formula: `$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$`
+3. Euler's identity: `$e^{i\pi} + 1 = 0$`
 
 ## Block Equations
 
@@ -88,18 +84,19 @@ For more complex equations or when you want the equation to be displayed on its 
 
 The Gaussian integral:
 
-$$
-\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
-$$
+```bash
+$$ \int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi} $$
+```
 
 The definition of the Riemann zeta function:
 
-$$
-\zeta(s) = \sum_{n=1}^{\infty} \frac{1}{n^s}
-$$
+```bash
+$$ \zeta(s) = \sum_{n=1}^{\infty} \frac{1}{n^s} $$
+```
 
 Maxwell's equations in differential form:
 
+```bash
 $$
 \begin{aligned}
 \nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
@@ -108,12 +105,13 @@ $$
 \nabla \times \mathbf{B} &= \mu_0\left(\mathbf{J} + \varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right)
 \end{aligned}
 $$
+```
 
 ## Using Mathematical Symbols
 
 LaTeX provides a wide range of mathematical symbols:
 
-- Greek letters: $\alpha$, $\beta$, $\gamma$, $\delta$, $\epsilon$, $\pi$
-- Operators: $\sum$, $\prod$, $\int$, $\partial$, $\nabla$
-- Relations: $\leq$, $\geq$, $\approx$, $\sim$, $\propto$
-- Logical symbols: $\forall$, $\exists$, $\neg$, $\wedge$, $\vee$
+- Greek letters: `$\alpha$`, `$\beta$`, `$\gamma$`, `$\delta$`, `$\epsilon$`, `$\pi$`
+- Operators: `$\sum$`, `$\prod$`, `$\int$`, `$\partial$`, `$\nabla$`
+- Relations: `$\leq$`, `$\geq$`, `$\approx$`, `$\sim$`, `$\propto$`
+- Logical symbols: `$\forall$`, `$\exists$`, `$\neg$`, `$\wedge$`, `$\vee$`

--- a/src/content/blog/how-to-add-latex-equations-in-blog-posts.md
+++ b/src/content/blog/how-to-add-latex-equations-in-blog-posts.md
@@ -1,17 +1,17 @@
 ---
 author: Alberto Perdomo
 pubDatetime: 2024-09-08T20:58:52.737Z
-title: Markdown and LaTeX
-slug: markdown-latex
+title: Adding LaTeX Equations in AstroPaper blog posts
 featured: false
 tags:
   - rendering
+  - docs
 description: How to use LaTeX equations in your Markdown files for AstroPaper.
 ---
 
-# Introduction to LaTeX Equations in Markdown
-
 This document demonstrates how to use LaTeX equations in your Markdown files for AstroPaper. LaTeX is a powerful typesetting system often used for mathematical and scientific documents.
+
+## Table of contents
 
 ## Instructions
 
@@ -21,49 +21,55 @@ In this section, you will find instructions on how to add support for LaTeX in y
 
 2. Update the Astro configuration to use the these libraries (see in **diff** format):
 
-```
-diff --git a/astro.config.ts b/astro.config.ts
-index 8386d5d..28a0cff 100644
---- a/astro.config.ts
-+++ b/astro.config.ts
-@@ -3,6 +3,8 @@ import tailwind from "@astrojs/tailwind";
- import react from "@astrojs/react";
- import remarkToc from "remark-toc";
- import remarkCollapse from "remark-collapse";
-+import remarkMath from 'remark-math';
-+import rehypeKatex from 'rehype-katex';
- import sitemap from "@astrojs/sitemap";
- import { SITE } from "./src/config";
- 
-@@ -25,6 +27,10 @@ export default defineConfig({
-           test: "Table of contents",
-         },
-       ],
-+      remarkMath,
-+    ],
-+    rehypePlugins: [
-+      rehypeKatex
-     ],
-     shikiConfig: {
-       // For more themes, visit https://shiki.style/themes
+```ts
+// astro.config.ts
 
+// other imports
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+
+export default defineConfig({
+  // other configs
+  markdown: {
+    remarkPlugins: [
+      remarkMath,
+      remarkToc,
+      [
+        remarkCollapse,
+        {
+          test: "Table of contents",
+        },
+      ],
+    ],
+    rehypePlugins: [rehypeKatex],
+    // other markdown configs
+  },
+  // other configs
+});
 ```
 
 3. Import KaTeX CSS in the main layout (see in **diff** format):
 
-```
-diff --git a/src/layouts/Layout.astro b/src/layouts/Layout.astro
-index decf1c7..a72a75f 100644
---- a/src/layouts/Layout.astro
-+++ b/src/layouts/Layout.astro
-@@ -132,6 +132,7 @@ const structuredData = {
-     <ViewTransitions />
+```html
+// src/layouts/Layout.astro
+
+---
+import { LOCALE, SITE } from "@config";
+
+// astro code
+---
+
+<!doctype html>
+
+// layout...
  
-     <script is:inline src="/toggle-theme.js"></script>
-+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css">
-   </head>
-   <body>
-     <slot />
+    <script is:inline src="/toggle-theme.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css">
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
 ```
 
 And *voilà*, this setup allows you to write LaTeX equations in your Markdown files, which will be rendered properly when the site is built. Once you do it, the rest of the document will appear rendered correctly. 

--- a/src/content/blog/latex-rendering.md
+++ b/src/content/blog/latex-rendering.md
@@ -1,0 +1,113 @@
+---
+author: Alberto Perdomo
+pubDatetime: 2024-09-08T20:58:52.737Z
+title: Markdown and LaTeX
+slug: markdown-latex
+featured: false
+tags:
+  - rendering
+description: How to use LaTeX equations in your Markdown files for AstroPaper.
+---
+
+# Introduction to LaTeX Equations in Markdown
+
+This document demonstrates how to use LaTeX equations in your Markdown files for AstroPaper. LaTeX is a powerful typesetting system often used for mathematical and scientific documents.
+
+## Instructions
+
+In this section, you will find instructions on how to add support for LaTeX in your Markdown files for AstroPaper. 
+
+1. Install the necessary dependencies by running `npm install rehype-katex remark-math katex`.
+
+2. Update the Astro configuration to use the these libraries (see in **diff** format):
+
+```
+diff --git a/astro.config.ts b/astro.config.ts
+index 8386d5d..28a0cff 100644
+--- a/astro.config.ts
++++ b/astro.config.ts
+@@ -3,6 +3,8 @@ import tailwind from "@astrojs/tailwind";
+ import react from "@astrojs/react";
+ import remarkToc from "remark-toc";
+ import remarkCollapse from "remark-collapse";
++import remarkMath from 'remark-math';
++import rehypeKatex from 'rehype-katex';
+ import sitemap from "@astrojs/sitemap";
+ import { SITE } from "./src/config";
+ 
+@@ -25,6 +27,10 @@ export default defineConfig({
+           test: "Table of contents",
+         },
+       ],
++      remarkMath,
++    ],
++    rehypePlugins: [
++      rehypeKatex
+     ],
+     shikiConfig: {
+       // For more themes, visit https://shiki.style/themes
+
+```
+
+3. Import KaTeX CSS in the main layout (see in **diff** format):
+
+```
+diff --git a/src/layouts/Layout.astro b/src/layouts/Layout.astro
+index decf1c7..a72a75f 100644
+--- a/src/layouts/Layout.astro
++++ b/src/layouts/Layout.astro
+@@ -132,6 +132,7 @@ const structuredData = {
+     <ViewTransitions />
+ 
+     <script is:inline src="/toggle-theme.js"></script>
++    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css">
+   </head>
+   <body>
+     <slot />
+```
+
+And *voilà*, this setup allows you to write LaTeX equations in your Markdown files, which will be rendered properly when the site is built. Once you do it, the rest of the document will appear rendered correctly. 
+
+## Inline Equations
+
+Inline equations are written between single dollar signs `$...$`. Here are some examples:
+
+1. The famous mass-energy equivalence formula: $E = mc^2$
+2. The quadratic formula: $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$
+3. Euler's identity: $e^{i\pi} + 1 = 0$
+
+## Block Equations
+
+For more complex equations or when you want the equation to be displayed on its own line, use double dollar signs `$$...$$`:
+
+The Gaussian integral:
+
+$$
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
+$$
+
+The definition of the Riemann zeta function:
+
+$$
+\zeta(s) = \sum_{n=1}^{\infty} \frac{1}{n^s}
+$$
+
+Maxwell's equations in differential form:
+
+$$
+\begin{aligned}
+\nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
+\nabla \cdot \mathbf{B} &= 0 \\
+\nabla \times \mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t} \\
+\nabla \times \mathbf{B} &= \mu_0\left(\mathbf{J} + \varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right)
+\end{aligned}
+$$
+
+## Using Mathematical Symbols
+
+LaTeX provides a wide range of mathematical symbols:
+
+- Greek letters: $\alpha$, $\beta$, $\gamma$, $\delta$, $\epsilon$, $\pi$
+- Operators: $\sum$, $\prod$, $\int$, $\partial$, $\nabla$
+- Relations: $\leq$, $\geq$, $\approx$, $\sim$, $\propto$
+- Logical symbols: $\forall$, $\exists$, $\neg$, $\wedge$, $\vee$


### PR DESCRIPTION
This PR introduces LaTeX equation rendering capability to AstroPaper, enhancing its functionality for technical and scientific writing. By integrating KaTeX, we now support rendering of both inline and block LaTeX equations in Markdown files.

I do think this will enlarge the use of AstroPaper in the scientific community. 

Many technical bloggers and documentation writers need to include mathematical equations in their content. Adding LaTeX support significantly expands AstroPaper's usefulness for these users, making it a more versatile platform for a wider range of creators.

## Changes Made

- Updated `astro.config.mjs` to include `remark-math` and `rehype-katex` plugins.
- Modified the `Layout.astro` file to include KaTeX CSS.
- Added necessary dependencies (`rehype-katex`, `remark-math`, and `katex`) to `package.json`.
- Created a sample Markdown file demonstrating LaTeX usage.