### PR TITLE
perf: preload font and load theme script asynchronously

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -112,7 +112,10 @@ const structuredData = {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap"
-      rel="stylesheet"
+      rel="preload"
+      as="style"
+      onload="this.onload=null; this.rel='stylesheet';"
+      crossorigin
     />
 
     <meta name="theme-color" content="" />
@@ -131,7 +134,7 @@ const structuredData = {
 
     <ViewTransitions />
 
-    <script is:inline src="/toggle-theme.js"></script>
+    <script is:inline src="/toggle-theme.js" async></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
Improve page performance by preloading the font with `as="style"` and loading the theme script asynchronously.