### PR TITLE
Fix post sorting on /posts/

### DIFF
--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -3,10 +3,11 @@ import { SITE } from "@config";
 import Posts from "@layouts/Posts.astro";
 import type { GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
+import getSortedPosts from "@utils/getSortedPosts";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
-  return paginate(posts, { pageSize: SITE.postPerPage });
+  return paginate(getSortedPosts(posts), { pageSize: SITE.postPerPage });
 }) satisfies GetStaticPaths;
 
 const { page } = Astro.props;

--- a/src/pages/posts/[page].astro
+++ b/src/pages/posts/[page].astro
@@ -3,10 +3,11 @@ import { SITE } from "@config";
 import Posts from "@layouts/Posts.astro";
 import type { GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
+import getSortedPosts from "@utils/getSortedPosts";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
-  return paginate(posts, { pageSize: SITE.postPerPage });
+  return paginate(getSortedPosts(posts), { pageSize: SITE.postPerPage });
 }) satisfies GetStaticPaths;
 
 const { page } = Astro.props;


### PR DESCRIPTION
I recently followed the v4.4.0 -> v4.5.0 update and noticed the out of order posts. This adds the date sorted posts back like they were in v4.4.0.