### PR TITLE
Replace Twitter to X

### DIFF
--- a/src/assets/socialIcons.ts
+++ b/src/assets/socialIcons.ts
@@ -55,14 +55,14 @@ const socialIcons = {
       <rect x="3" y="5" width="18" height="14" rx="2"></rect>
       <polyline points="3 7 12 13 21 7"></polyline>
     </svg>`,
-  Twitter: `<svg
+  X: `<svg  
       xmlns="http://www.w3.org/2000/svg"
       class="icon-tabler"
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-      <path d="M22 4.01c-1 .49 -1.98 .689 -3 .99c-1.121 -1.265 -2.783 -1.335 -4.38 -.737s-2.643 2.06 -2.62 3.737v1c-3.245 .083 -6.135 -1.395 -8 -4c0 0 -4.182 7.433 4 11c-1.872 1.247 -3.739 2.088 -6 2c3.308 1.803 6.913 2.423 10.034 1.517c3.58 -1.04 6.522 -3.723 7.651 -7.742a13.84 13.84 0 0 0 .497 -3.753c-.002 -.249 1.51 -2.772 1.818 -4.013z"></path>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+      <path d="M4 4l11.733 16h4.267l-11.733 -16z" /><path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
     </svg>`,
   Twitch: `<svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -16,9 +16,9 @@ const shareLinks = [
     linkTitle: `Share this post on Facebook`,
   },
   {
-    name: "Twitter",
-    href: "https://twitter.com/intent/tweet?url=",
-    linkTitle: `Tweet this post`,
+    name: "X",
+    href: "https://x.com/intent/post?url=",
+    linkTitle: `Share this post on X`,
   },
   {
     name: "Telegram",

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,9 +63,9 @@ export const SOCIALS: SocialObjects = [
     active: false,
   },
   {
-    name: "Twitter",
+    name: "X",
     href: "https://github.com/satnaing/astro-paper",
-    linkTitle: `${SITE.title} on Twitter`,
+    linkTitle: `${SITE.title} on X`,
     active: false,
   },
   {


### PR DESCRIPTION
Replacing the `old twitter` icon and share link to `X`

## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

As the twitter was changed to `X`, I guess we could replace it!


## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)

It won't  crash the page, But who uses twitter, it wont appear ... he needs to switch to `X`
Is it considered a Break change?

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

it will be like this

![Screenshot from 2024-10-29 10-34-48](https://github.com/user-attachments/assets/66e0b0f3-73f1-49d3-b10d-85b305be0c05)
![Screenshot from 2024-10-29 10-34-17](https://github.com/user-attachments/assets/0e2915ba-b82d-4eb6-874f-e445587b9286)

