### PR TITLE
fix: fix the archive page sorting

### DIFF
--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -59,9 +59,19 @@ const MonthMap: Record<string, string> = {
                     <sup class="text-xs">{monthGroup.length}</sup>
                   </div>
                   <ul>
-                    {monthGroup.map(({ data, slug }) => (
-                      <Card href={`/posts/${slug}`} frontmatter={data} />
-                    ))}
+                    {monthGroup
+                      .sort(
+                        (a, b) =>
+                          Math.floor(
+                            new Date(b.data.pubDatetime).getTime() / 1000
+                          ) -
+                          Math.floor(
+                            new Date(a.data.pubDatetime).getTime() / 1000
+                          )
+                      )
+                      .map(({ data, slug }) => (
+                        <Card href={`/posts/${slug}`} frontmatter={data} />
+                      ))}
                   </ul>
                 </div>
               ))}


### PR DESCRIPTION
## Description

Fix the archive page sorting.
Sort the archive page by `pubDatetime`.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)


