### PR TITLE
fix: Improved view transition animation for post titles

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -77,7 +77,7 @@ const nextPost =
     </button>
   </div>
   <main id="main-content">
-    <h1 transition:name={slugifyStr(title)} class="post-title">{title}</h1>
+    <h1 transition:name={slugifyStr(title)} class="post-title inline-block">{title}</h1>
     <Datetime
       pubDatetime={pubDatetime}
       modDatetime={modDatetime}


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

The view transition animation of the "Post Title (h1, h2, h3...)" between the post list pages and the post pages is weird,
because of the width mismatch of titles among these pages.

Solution: 
Making the title in post page an inline-block, like what a title on list page is.

See slow motion video:

Currently:

https://github.com/user-attachments/assets/b44727e8-cac2-4eeb-9ffa-4fb9a1751965

After fix:

https://github.com/user-attachments/assets/e2601111-b3aa-4a01-8fa8-3efe65dfabf8


## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Others (any other types not listed above)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

None

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

None
