### PR TITLE
feat: use the original tag name for display

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -1,10 +1,11 @@
 ---
 export interface Props {
   tag: string;
+  tagName: string;
   size?: "sm" | "lg";
 }
 
-const { tag, size = "sm" } = Astro.props;
+const { tag, tagName, size = "sm" } = Astro.props;
 ---
 
 <li
@@ -24,7 +25,7 @@ const { tag, size = "sm" } = Astro.props;
         d="M16.018 3.815 15.232 8h-4.966l.716-3.815-1.964-.37L8.232 8H4v2h3.857l-.751 4H3v2h3.731l-.714 3.805 1.965.369L8.766 16h4.966l-.714 3.805 1.965.369.783-4.174H20v-2h-3.859l.751-4H21V8h-3.733l.716-3.815-1.965-.37zM14.106 14H9.141l.751-4h4.966l-.752 4z"
       ></path>
     </svg>
-    &nbsp;<span>{tag}</span>
+    &nbsp;<span>{tagName}</span>
   </a>
 </li>
 

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -91,7 +91,7 @@ const nextPost =
     </article>
 
     <ul class="my-8">
-      {tags.map(tag => <Tag tag={slugifyStr(tag)} />)}
+      {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
     </ul>
 
     <div

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -17,7 +17,7 @@ let tags = getUniqueTags(posts);
   <Header activeNav="tags" />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
-      {tags.map(({ tag }) => <Tag {tag} size="lg" />)}
+      {tags.map(({ tag, tagName }) => <Tag {tag} {tagName} size="lg" />)}
     </ul>
   </Main>
   <Footer />


### PR DESCRIPTION
## Description

This PR modifies tag display to show original tag names instead of slugified versions in the frontend. 

Currently, tags like `JavaScript` are being slugified to `java-script` in the display, which affects readability and professional appearance. This change will maintain the original tag names for better user experience.
