### PR TITLE
fix: reverse theme icon display logic to match user expectations

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -20,12 +20,12 @@
     --color-card-muted: 138, 51, 2;
     --color-border: 171, 75, 8;
   }
-  #sun-svg,
-  html[data-theme="dark"] #moon-svg {
-    display: none;
-  }
   #moon-svg,
   html[data-theme="dark"] #sun-svg {
+    display: none;
+  }
+  #sun-svg,
+  html[data-theme="dark"] #moon-svg {
     display: block;
   }
   body {


### PR DESCRIPTION
Following common design patterns for theme toggles

## What's Changed

Fixed the theme toggle icon display logic to better match user expectations:
- Light theme now shows sun icon (previously showed moon)
- Dark theme now shows moon icon (previously showed sun)