### PR TITLE
fix: embed font weight param in URL

### DIFF
--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -1,8 +1,9 @@
 async function loadGoogleFont(
   font: string,
-  text: string
+  text: string,
+  weight: number
 ): Promise<ArrayBuffer> {
-  const API = `https://fonts.googleapis.com/css2?family=${font}&text=${encodeURIComponent(text)}`;
+  const API = `https://fonts.googleapis.com/css2?family=${font}:wght@${weight}&text=${encodeURIComponent(text)}`;
 
   const css = await (
     await fetch(API, {
@@ -51,7 +52,7 @@ async function loadGoogleFonts(
 
   const fonts = await Promise.all(
     fontsConfig.map(async ({ name, font, weight, style }) => {
-      const data = await loadGoogleFont(font, text);
+      const data = await loadGoogleFont(font, text, weight);
       return { name, data, weight, style };
     })
   );


### PR DESCRIPTION
The font weight parameter was present but not being passed to the URL. This PR ensures it is included. 

No breaking changes.

- [x] Bug Fix (non-breaking change which fixes an issue)

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
