### PR TITLE
fix: prevent overflow by adding line breaks in table codes

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -29,9 +29,15 @@
   pre:has(code) {
     @apply border border-border;
   }
-  code,
-  blockquote {
-    word-wrap: break-word;
+
+  .prose code,
+  .prose blockquote {
+    @apply break-words;
+  }
+
+  .prose table code {
+    /* add line breaks whenever necessary for codes under table */
+    @apply break-all;
   }
 
   pre > code {


### PR DESCRIPTION
## Description

Horizontal overflow occurs when a code block in markdown table is too long. This PR prevents that by adding line breaks (`break-all`) in codes inside table.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
