### PR TITLE
fix: ensure only one search bar is displayed on nav link clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## v5.1.1 (2025-03-20)
+
+### Fix
+
+- initial light mode flash in dark mode (#488)
+- broken editPost link and update editPost logic  (#487)
+- prevent overflow by adding line breaks in table codes (#485)
+
 ## v5.1.0 (2025-03-18)
 
 ### Feat

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-paper",
   "type": "module",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "scripts": {
     "dev": "astro dev",
     "build": "astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/",

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -78,7 +78,14 @@ const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
     });
   }
 
-  document.addEventListener("astro:after-swap", initSearch);
+  document.addEventListener("astro:after-swap", () => {
+    const pagefindSearch = document.querySelector("#pagefind-search");
+
+    // if pagefind search form already exists, don't initialize search component
+    if (pagefindSearch && pagefindSearch.querySelector("form")) return;
+
+    initSearch();
+  });
   initSearch();
 </script>
 


### PR DESCRIPTION
## Description

Multiple search bars appear whenever Search nav link is clicked on `/search` page.

https://github.com/user-attachments/assets/8b98d3f0-6521-46ca-9696-149a1d0290d3

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #465
