### PR TITLE
fix: add types for constants to avoid type errors when empty

### DIFF
--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -5,22 +5,22 @@ import LinkButton from "./LinkButton.astro";
 const URL = Astro.url;
 ---
 
-<div
-  class="flex flex-col flex-wrap items-center justify-center gap-1 sm:items-start"
->
-  <span class="italic">Share this post on:</span>
-  <div class="text-center">
-    {
-      SHARE_LINKS.map(social => (
-        <LinkButton
-          href={`${social.href + URL}`}
-          class="scale-90 p-2 hover:rotate-6 sm:p-1"
-          title={social.linkTitle}
-        >
-          <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
-          <span class="sr-only">{social.linkTitle}</span>
-        </LinkButton>
-      ))
-    }
-  </div>
-</div>
+{
+  SHARE_LINKS.length > 0 && (
+    <div class="flex flex-none flex-col items-center justify-center gap-1 sm:items-end">
+      <span class="italic">Share this post on:</span>
+      <div class="text-center">
+        {SHARE_LINKS.map(social => (
+          <LinkButton
+            href={`${social.href + URL}`}
+            class="scale-90 p-2 hover:rotate-6 sm:p-1"
+            title={social.linkTitle}
+          >
+            <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
+            <span class="sr-only">{social.linkTitle}</span>
+          </LinkButton>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -6,12 +6,20 @@ export interface Props {
   centered?: boolean;
 }
 
+type Social = {
+  href: string;
+  linkTitle: string;
+  name: string;
+  icon: any;
+};
+
+const socialLinks = (SOCIALS.length > 0 ? SOCIALS : []) as unknown as Social[];
 const { centered = false } = Astro.props;
 ---
 
 <div class:list={["flex-wrap justify-center gap-1", { flex: centered }]}>
   {
-    SOCIALS.map(social => (
+    socialLinks.map(social => (
       <LinkButton
         href={social.href}
         class="p-2 hover:rotate-6 sm:p-1"

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -6,20 +6,12 @@ export interface Props {
   centered?: boolean;
 }
 
-type Social = {
-  href: string;
-  linkTitle: string;
-  name: string;
-  icon: any;
-};
-
-const socialLinks = (SOCIALS.length > 0 ? SOCIALS : []) as unknown as Social[];
 const { centered = false } = Astro.props;
 ---
 
 <div class:list={["flex-wrap justify-center gap-1", { flex: centered }]}>
   {
-    socialLinks.map(social => (
+    SOCIALS.map(social => (
       <LinkButton
         href={social.href}
         class="p-2 hover:rotate-6 sm:p-1"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import type { Props } from "astro";
 import IconMail from "@/assets/icons/IconMail.svg";
 import IconGitHub from "@/assets/icons/IconGitHub.svg";
 import IconBrandX from "@/assets/icons/IconBrandX.svg";
@@ -8,11 +9,18 @@ import IconTelegram from "@/assets/icons/IconTelegram.svg";
 import IconPinterest from "@/assets/icons/IconPinterest.svg";
 import { SITE } from "@/config";
 
-export const SOCIALS = [
+interface Social {
+  name: string;
+  href: string;
+  linkTitle: string;
+  icon: (_props: Props) => Element;
+}
+
+export const SOCIALS: Social[] = [
   {
     name: "Github",
     href: "https://github.com/satnaing/astro-paper",
-    linkTitle: ` ${SITE.title} on Github`,
+    linkTitle: `${SITE.title} on Github`,
     icon: IconGitHub,
   },
   {
@@ -35,7 +43,7 @@ export const SOCIALS = [
   },
 ] as const;
 
-export const SHARE_LINKS = [
+export const SHARE_LINKS: Social[] = [
   {
     name: "WhatsApp",
     href: "https://wa.me/?text=",


### PR DESCRIPTION
## Description

Modifying the `Socials.astro` file, add type definitions and conditional rendering to prevent type errors when `SOCIALS` is empty.

This modification resolves the TypeScript error when the `SOCIALS` array is empty by adding type definitions and using type assertions. When the array is empty, the map function does not execute, so no social icons are attempted to be rendered. This approach maintains the integrity of the original logic while simply adding type safety measures.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)


## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #500 
