### PR TITLE
docs: update customize-color-schemes doc to match current files

### DIFF
--- a/src/data/blog/customizing-astropaper-theme-color-schemes.md
+++ b/src/data/blog/customizing-astropaper-theme-color-schemes.md
@@ -67,34 +67,40 @@ The **primaryColorScheme** variable can hold two values\_ `"light"`, `"dark"`. Y
 
 ## Customize color schemes
 
-Both light & dark color schemes of AstroPaper theme can be customized. You can do this in `src/styles/base.css` file.
+Both light & dark color schemes of AstroPaper theme can be customized. You can do this in `src/styles/global.css` file.
 
 ```css
-/* file: src/styles/base.css */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+/* file: src/styles/global.css */
+@import "tailwindcss";
+@import "./typography.css";
 
-@layer base {
-  :root,
-  html[data-theme="light"] {
-    --color-fill: 251, 254, 251;
-    --color-text-base: 40, 39, 40;
-    --color-accent: 0, 108, 172;
-    --color-card: 230, 230, 230;
-    --color-card-muted: 205, 205, 205;
-    --color-border: 236, 233, 233;
-  }
-  html[data-theme="dark"] {
-    --color-fill: 47, 55, 65;
-    --color-text-base: 230, 230, 230;
-    --color-accent: 26, 217, 217;
-    --color-card: 63, 75, 90;
-    --color-card-muted: 89, 107, 129;
-    --color-border: 59, 70, 85;
-  }
-  /* other styles */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
+:root,
+html[data-theme="light"] {
+  --background: #fdfdfd;
+  --foreground: #282728;
+  --accent: #006cac;
+  --muted: #e6e6e6;
+  --border: #ece9e9;
 }
+
+html[data-theme="dark"] {
+  --background: #212737;
+  --foreground: #eaedf3;
+  --accent: #ff6b01;
+  --muted: #343f60bf;
+  --border: #ab4b08;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
+  --color-muted: var(--muted);
+  --color-border: var(--border);
+}
+/* other styles */
 ```
 
 In AstroPaper theme, `:root` and `html[data-theme="light"]` selectors are used as the light color scheme and `html[data-theme="dark"]` is used the dark color scheme. If you want to customize your custom color scheme, you have to specify your light color scheme inside `:root`,`html[data-theme="light"]` and dark color scheme inside `html[data-theme="dark"]`.
@@ -105,11 +111,10 @@ Here is the detail explanation of color properties.
 
 | Color Property       | Definition & Usage                                         |
 | -------------------- | ---------------------------------------------------------- |
-| `--color-fill`       | Primary color of the website. Usually the main background. |
-| `--color-text-base`  | Secondary color of the website. Usually the text color.    |
+| `--color-background` | Primary color of the website. Usually the main background. |
+| `--color-foreground` | Secondary color of the website. Usually the text color.    |
 | `--color-accent`     | Accent color of the website. Link color, hover color etc.  |
-| `--color-card`       | Card, scrollbar and code background color (like `this`).   |
-| `--color-card-muted` | Card and scrollbar background color for hover state etc.   |
+| `--color-muted`      | Card and scrollbar background color for hover state etc.   |
 | `--color-border`     | Border color. Especially used in horizontal row (hr)       |
 
 Here is an example of changing the light color scheme.
@@ -119,12 +124,11 @@ Here is an example of changing the light color scheme.
   /* lobster color scheme */
   :root,
   html[data-theme="light"] {
-    --color-fill: 246, 238, 225;
-    --color-text-base: 1, 44, 86;
-    --color-accent: 225, 74, 57;
-    --color-card: 220, 152, 145;
-    --color-card-muted: 233, 119, 106;
-    --color-border: 220, 152, 145;
+    --background: #f6eee1;
+    --foreground: #012c56;
+    --accent: #e14a39;
+    --muted: #efd8b0;
+    --border: #dc9891;
   }
 }
 ```

--- a/src/data/blog/customizing-astropaper-theme-color-schemes.md
+++ b/src/data/blog/customizing-astropaper-theme-color-schemes.md
@@ -1,6 +1,7 @@
 ---
 author: Sat Naing
 pubDatetime: 2022-09-25T15:20:35Z
+modDatetime: 2025-06-09T07:42:54.791Z
 title: Customizing AstroPaper theme color schemes
 featured: false
 draft: false
@@ -92,45 +93,36 @@ html[data-theme="dark"] {
   --muted: #343f60bf;
   --border: #ab4b08;
 }
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-accent: var(--accent);
-  --color-muted: var(--muted);
-  --color-border: var(--border);
-}
 /* other styles */
 ```
 
-In AstroPaper theme, `:root` and `html[data-theme="light"]` selectors are used as the light color scheme and `html[data-theme="dark"]` is used the dark color scheme. If you want to customize your custom color scheme, you have to specify your light color scheme inside `:root`,`html[data-theme="light"]` and dark color scheme inside `html[data-theme="dark"]`.
+In the AstroPaper theme, the `:root` and `html[data-theme="light"]` selectors define the light color scheme, while `html[data-theme="dark"]` defines the dark color scheme.
 
-Colors are declared in CSS custom property (CSS Variable) notation. Color property values are written in rgb values. (Note: instead of `rgb(40, 39, 40)`, only specify `40, 39, 40`)
+To customize your own color scheme, specify your light colors inside `:root, html[data-theme="light"]`, and your dark colors inside `html[data-theme="dark"]`.
 
 Here is the detail explanation of color properties.
 
-| Color Property       | Definition & Usage                                         |
-| -------------------- | ---------------------------------------------------------- |
-| `--color-background` | Primary color of the website. Usually the main background. |
-| `--color-foreground` | Secondary color of the website. Usually the text color.    |
-| `--color-accent`     | Accent color of the website. Link color, hover color etc.  |
-| `--color-muted`      | Card and scrollbar background color for hover state etc.   |
-| `--color-border`     | Border color. Especially used in horizontal row (hr)       |
+| Color Property | Definition & Usage                                         |
+| -------------- | ---------------------------------------------------------- |
+| `--background` | Primary color of the website. Usually the main background. |
+| `--foreground` | Secondary color of the website. Usually the text color.    |
+| `--accent`     | Accent color of the website. Link color, hover color etc.  |
+| `--muted`      | Card and scrollbar background color for hover state etc.   |
+| `--border`     | Border color. Especially used in horizontal row (hr)       |
 
 Here is an example of changing the light color scheme.
 
 ```css
-@layer base {
-  /* lobster color scheme */
-  :root,
-  html[data-theme="light"] {
-    --background: #f6eee1;
-    --foreground: #012c56;
-    --accent: #e14a39;
-    --muted: #efd8b0;
-    --border: #dc9891;
-  }
+/* other styles */
+:root,
+html[data-theme="light"] {
+  --background: #f6eee1;
+  --foreground: #012c56;
+  --accent: #e14a39;
+  --muted: #efd8b0;
+  --border: #dc9891;
 }
+/* other styles */
 ```
 
 > Check out some [predefined color schemes](https://astro-paper.pages.dev/posts/predefined-color-schemes/) AstroPaper has already crafted for you.


### PR DESCRIPTION

## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

While working with AstroPaper I noticed the docs for customizing color schemes were outdated.

Tried my best to update the docs for this, not sure about the detail explanation though, because I haven't customized the theme myself yet :)

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->
