### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/satnaing/astro-paper/security/code-scanning/1](https://github.com/satnaing/astro-paper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily performs read operations (e.g., checking out code, installing dependencies, and building), we will set the `contents` permission to `read`. This ensures that the workflow has the minimal permissions required to function correctly.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs, including the `build` job. This approach avoids redundancy and ensures consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
