### PR TITLE
fix: remove extra padding in fenced code blocks

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -71,7 +71,7 @@
     }
 
     .astro-code code {
-      @apply bg-inherit;
+      @apply bg-inherit p-0;
     }
 
     blockquote {


### PR DESCRIPTION
## Description

In normal `code` blocks, there's a padding for making them stand out.
However, this affects the fenced code blocks, causing them to have unnecessary extra padding.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes #539
