### PR TITLE
fix: typo in astro-paper-v5 blog post

### DIFF
--- a/src/data/blog/_releases/astro-paper-5.md
+++ b/src/data/blog/_releases/astro-paper-5.md
@@ -82,7 +82,7 @@ The project structure has been reorganized. The `src/config.ts` file now only co
 ## Other notable changes
 
 - The blog posts directory has been updated from `src/content/blog/` to `src/data/blog/`.
-- Conllection definitions file (`src/content/config.ts`) is now replaced with `src/content.config.ts`.
+- Collection definitions file (`src/content/config.ts`) is now replaced with `src/content.config.ts`.
 - Various dependencies have been upgraded for improved performance and security.
 - Removed `IBM Plex Mono` font and switched to the default system mono font.
 - The `Go back` button logic has been updated. Now, instead of triggering the browser's history API, AstroPaper v5 uses the browser session to temporarily store the back URL. If no back URL exists in the session, it will redirect to the homepage.


### PR DESCRIPTION
## Description

Fixes a minor very typo changing "Conllection" to Collection"

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

n/a

## Related Issue

n/a

Closes:n/a
