### PR TITLE
fix: update syntax highlighting transformer styles

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -71,7 +71,7 @@
     }
 
     .astro-code code {
-      @apply bg-inherit p-0;
+      @apply flex-[1_0_100%] bg-inherit p-0;
     }
 
     blockquote {
@@ -93,7 +93,7 @@
 
   /* ===== Code Blocks & Syntax Highlighting ===== */
   .astro-code {
-    @apply border bg-(--shiki-light-bg) text-(--shiki-light) outline-border [&_span]:text-(--shiki-light);
+    @apply flex border bg-(--shiki-light-bg) text-(--shiki-light) outline-border [&_span]:text-(--shiki-light);
   }
 
   html[data-theme="dark"] .astro-code {
@@ -104,13 +104,13 @@
   /* https://shiki.style/packages/transformers */
   .astro-code {
     .line.diff.add {
-      @apply relative *:bg-green-500/20 before:absolute before:-left-3 before:text-green-500 before:content-['+'];
+      @apply relative inline-block w-full bg-green-400/20 before:absolute before:-left-3 before:text-green-500 before:content-['+'];
     }
     .line.diff.remove {
-      @apply relative *:bg-red-500/30 before:absolute before:-left-3 before:text-red-500 before:content-['-'];
+      @apply relative inline-block w-full bg-red-500/20 before:absolute before:-left-3 before:text-red-500 before:content-['-'];
     }
     .line.highlighted {
-      @apply *:!bg-slate-400/20;
+      @apply inline-block w-full bg-slate-400/20;
     }
     .highlighted-word {
       @apply rounded-sm border border-border px-0.5 py-px;


### PR DESCRIPTION
## Description

Improve syntax highlighting transformer styles.

| Before | After |
| --- | --- |
| <img width="1804" height="1764" alt="before-update" src="https://github.com/user-attachments/assets/894e244b-c522-4bf9-b4d8-7741b913eddb" /> | <img width="1804" height="1764" alt="after-update" src="https://github.com/user-attachments/assets/28053844-9877-4a6f-b6e9-beef89c020da" /> |

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
