### PR TITLE
fix: skip invalid code block metadata without key-value pairs

### DIFF
--- a/src/utils/transformers/fileName.js
+++ b/src/utils/transformers/fileName.js
@@ -29,6 +29,7 @@ export const transformerFileName = ({
 
     for (const item of raw) {
       const [key, value] = item.split("=");
+      if (!key || !value) continue;
       metaMap.set(key, value.replace(/["'`]/g, ""));
     }
 


### PR DESCRIPTION
## Description

This ensures compatibility with transformers like `transformerMetaHighlight`, which may include metadata without key-value formatting.

Previously, metadata entries without an = would cause [key, value] to be undefined, potentially introducing invalid entries into the map. We now skip such entries to ensure only valid key-value pairs are parsed.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [X ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

## Related Issue
