### PR TITLE
fix: open share links in new tab to keep users on site

### DIFF
--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -13,6 +13,7 @@ const URL = Astro.url;
         {SHARE_LINKS.map(social => (
           <LinkButton
             href={`${social.href + URL}`}
+            target="_blank"
             class="scale-90 p-2 hover:rotate-6 sm:p-1"
             title={social.linkTitle}
           >


### PR DESCRIPTION
## Description

When users click on share links (Twitter, Facebook, etc.), the links now open in a new tab instead of navigating away from the current page. This keeps readers on the article while still allowing them to share content on social media.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This is a minimal change that adds `target="_blank"` to the share links in `ShareLinks.astro`. The `LinkButton` component already supports all standard anchor attributes through `HTMLAttributes<"a">`, so this works seamlessly.

## Related Issue

Closes: #566

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)