### PR TITLE
docs: fix invalid Noto Sans font configuration for OG images

### DIFF
--- a/src/data/blog/dynamic-og-images.md
+++ b/src/data/blog/dynamic-og-images.md
@@ -61,14 +61,14 @@ async function loadGoogleFonts(
     },
     {
       name: "Noto Sans JP",
-      font: "Noto+Sans+JP:wght@700",
+      font: "Noto+Sans+JP",
       weight: 700,
       style: "normal",
     },
     { name: "Noto Sans", font: "Noto+Sans", weight: 400, style: "normal" },
     {
       name: "Noto Sans",
-      font: "Noto+Sans:wght@700",
+      font: "Noto+Sans",
       weight: 700,
       style: "normal",
     },


### PR DESCRIPTION
## Description

Fixes invalid font configuration in the dynamic OG image documentation. The example code for using Noto Sans fonts contained duplicate `:wght@700` in the font property, which causes the Google Fonts API request to fail.

The `loadGoogleFont` function already appends `:wght@${weight}` to the font URL, so having `:wght@700` in the `font` property creates an invalid URL like `Noto+Sans:wght@700:wght@700`.

## Types of changes

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Before this fix, users following the documentation would encounter errors when generating OG images with Noto Sans fonts because the Google Fonts API would return an error for the malformed URL.

## Related Issue

Closes: #499

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)