### PR TITLE
Fix typo in blog post description

### DIFF
--- a/src/data/blog/adding-new-post.md
+++ b/src/data/blog/adding-new-post.md
@@ -9,7 +9,7 @@ draft: false
 tags:
   - docs
 description:
-  Some rules & recommendations for creating or adding new posts using AstroPaperr
+  Some rules & recommendations for creating or adding new posts using AstroPaper
   theme.
 ---
 


### PR DESCRIPTION
## Description
Fixed a small typo in the front matter of the blog posts (src/data/blog/adding-new-post.md). The description field was referring to **AstroPaper** as **AstroPaperr** (with an extra trailing r). This PR fixes that typo.
I found this issue when incorporating this theme into my blog. Great theme, btw!

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This is a small typo - so no further comments needed.

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable --> Not applicable
