### PR TITLE
fix: clear BackToTop float to prevent nav layout shift

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -126,7 +126,7 @@ const nextPost =
 
     <ShareLinks />
 
-    <hr class="my-6 border-dashed" />
+    <hr class="my-6 clear-end border-dashed" />
 
     <!-- Previous/Next Post Buttons -->
     <div data-pagefind-ignore class="grid grid-cols-1 gap-6 sm:grid-cols-2">


### PR DESCRIPTION
When SHARE_LINKS is empty, the BackToTopButton's md:float-end was not cleared before the prev/next navigation grid, pushing buttons out of alignment. Adding clear-end on the separating `<hr>` fixes this.

Fixes #614

## Description

When `SHARE_LINKS` is empty in `src/constants.ts`, the `ShareLinks` component renders nothing. This means the `BackToTopButton`'s `md:float-end` is not cleared before the prev/next navigation grid, causing the "Next Post" / "Previous Post" buttons to shift left instead of staying properly aligned.

The fix adds `clear-end` on the `<hr>` that separates the share links section from the navigation, ensuring the float is always cleared regardless of whether share links are present.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Single-line change in `src/layouts/PostDetails.astro` (line 129):

```diff
- <hr class="my-6 border-dashed" />
+ <hr class="my-6 clear-end border-dashed" />
```

Tested both with empty and populated `SHARE_LINKS` — no regression.

## Related Issue

Closes: #614
