### PR TITLE
feat(docs): add ResponsiveTable to use it in MDX posts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@
 !.prettierrc
 !eslint.config.js
 !README.md
+
+# Ignore MDX files
+*.mdx

--- a/src/components/ResponsiveTable.astro
+++ b/src/components/ResponsiveTable.astro
@@ -1,0 +1,34 @@
+---
+type Props = {
+  class?: string;
+  variant?: /** No borders */
+    | "minimal"
+    /** 1st, 3rd, 5th … body rows tinted — classic zebra. */
+    | "striped"
+    /** 1st, 3rd, 5th … body rows tinted + no borders. */
+    | "striped-minimal";
+};
+
+const { class: className, variant } = Astro.props;
+
+const variantClasses = {
+  minimal: "[&_td]:border-0 [&_th]:border-0",
+  striped: "[&_tbody_tr]:odd:bg-muted/25",
+};
+---
+
+<div
+  data-table-variant={variant}
+  class:list={[
+    "overflow-hidden [&_table]:my-0 [&_table]:min-w-xl",
+    variant === "minimal" && variantClasses.minimal,
+    variant === "striped" && variantClasses.striped,
+    variant === "striped-minimal" &&
+      `${variantClasses.minimal} ${variantClasses.striped}`,
+    className,
+  ]}
+>
+  <div class="relative w-full overflow-x-auto">
+    <slot />
+  </div>
+</div>

--- a/src/content/posts/adding-new-post.mdx
+++ b/src/content/posts/adding-new-post.mdx
@@ -1,17 +1,16 @@
 ---
 author: Sat Naing
 pubDatetime: 2022-09-23T15:22:00Z
-modDatetime: 2026-05-04T00:00:00Z
+modDatetime: 2026-05-10T06:57:36.673Z
 title: Adding new posts in AstroPaper theme
 slug: adding-new-posts-in-astropaper-theme
 featured: true
 draft: false
 tags:
   - docs
-description:
-  Some rules & recommendations for creating or adding new posts using AstroPaper
-  theme.
+description: "Some rules & recommendations for creating or adding new posts using AstroPaper theme."
 ---
+import ResponsiveTable from '@/components/ResponsiveTable.astro';
 
 Here are some rules/recommendations, tips & tricks for creating new posts in AstroPaper blog theme.
 
@@ -21,7 +20,8 @@ Here are some rules/recommendations, tips & tricks for creating new posts in Ast
     alt="Free Classic wooden desk with writing materials, vintage clock, and a leather bag. Stock Photo"
   />
   <figcaption class="text-center">
-    Photo by <a href="https://www.pexels.com/photo/brown-wooden-desk-159618/">Pixabay</a>
+    Photo by{" "}
+    <a href="https://www.pexels.com/photo/brown-wooden-desk-159618/">Pixabay</a>
   </figcaption>
 </figure>
 
@@ -52,6 +52,8 @@ Frontmatter is the main place to store metadata about a blog post. It lives at t
 
 Here is the list of frontmatter properties for each post:
 
+<ResponsiveTable variant="striped-minimal">
+
 | Property           | Description                                                                                                                         | Remark                                         |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | **_title_**        | Title of the post. (h1)                                                                                                             | required<sup>\*</sup>                          |
@@ -66,6 +68,8 @@ Here is the list of frontmatter properties for each post:
 | **_canonicalURL_** | Canonical URL (absolute), in case the article already exists on another source.                                                     | default = `Astro.site` + `Astro.url.pathname`  |
 | **_hideEditPost_** | Hide the edit-post button under the post title. Applies only to the current post.                                                   | default = false                                |
 | **_timezone_**     | Specify a timezone in IANA format for the current post. Overrides the global `site.timezone` config for this post only.             | default = `site.timezone`                      |
+
+</ResponsiveTable>
 
 > Tip! You can get an ISO 8601 datetime by running `new Date().toISOString()` in the console.
 
@@ -116,7 +120,6 @@ These snippets live in `.vscode/astro-paper.code-snippets`. If you use VS Code (
 
 By default, a post does not include any table of contents (TOC). To include one, write `Table of contents` as an h2 heading (`##` in Markdown) and place it where you want it to appear:
 
-<!-- prettier-ignore-start -->
 ```md
 ---
 # frontmatter
@@ -129,7 +132,6 @@ Here are some recommendations, tips & tricks for creating new posts in AstroPape
 
 <!-- the rest of the post -->
 ```
-<!-- prettier-ignore-end -->
 
 ## Headings
 

--- a/src/content/posts/customizing-astropaper-theme-color-schemes.mdx
+++ b/src/content/posts/customizing-astropaper-theme-color-schemes.mdx
@@ -1,7 +1,7 @@
 ---
 author: Sat Naing
 pubDatetime: 2022-09-25T15:20:35Z
-modDatetime: 2026-05-04T00:00:00Z
+modDatetime: 2026-05-10T06:57:06.476Z
 title: Customizing AstroPaper theme color schemes
 featured: false
 draft: false
@@ -12,6 +12,7 @@ description:
   How you can enable/disable light & dark mode; and customize color schemes
   of AstroPaper theme.
 ---
+import ResponsiveTable from '@/components/ResponsiveTable.astro';
 
 This post will explain how you can enable/disable light & dark mode for the website. Moreover, you'll learn how you can customize color schemes of the entire website.
 
@@ -68,6 +69,8 @@ To customize your own color scheme, specify your light colors inside `:root, [da
 
 Here is a detailed explanation of each color property:
 
+<ResponsiveTable variant="minimal" class="max-sm:-mx-4 [&_td]:first-of-type:text-nowrap">
+
 | Color Property        | Definition & Usage                                                    |
 | --------------------- | --------------------------------------------------------------------- |
 | `--background`        | Primary color of the website. Usually the main background.            |
@@ -77,6 +80,8 @@ Here is a detailed explanation of each color property:
 | `--muted`             | Muted background color. Used for cards, tags, and hover states.       |
 | `--muted-foreground`  | Text color displayed on top of `--muted` backgrounds.                 |
 | `--border`            | Border color. Used for dividers and visual separation.                |
+
+</ResponsiveTable>
 
 Here is an example of changing the light color scheme:
 

--- a/src/content/posts/how-to-configure-astropaper-theme.mdx
+++ b/src/content/posts/how-to-configure-astropaper-theme.mdx
@@ -1,7 +1,7 @@
 ---
 author: Sat Naing
 pubDatetime: 2022-09-23T04:58:53Z
-modDatetime: 2026-05-04T00:00:00Z
+modDatetime: 2026-05-10T06:57:59.237Z
 title: How to configure AstroPaper theme
 slug: how-to-configure-astropaper-theme
 featured: true
@@ -11,6 +11,7 @@ tags:
   - docs
 description: How you can make AstroPaper theme absolutely yours.
 ---
+import ResponsiveTable from '@/components/ResponsiveTable.astro';
 
 AstroPaper is a highly customizable Astro blog theme. With AstroPaper, you can customize everything according to your personal taste. This article will explain how you can make some customizations easily in the config file.
 
@@ -69,6 +70,8 @@ export default defineAstroPaperConfig({
 
 ### `site` options
 
+<ResponsiveTable>
+
 | Option               | Description                                                                                                                                    |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`                | Your deployed website URL. Used for canonical URLs, OG image URLs, RSS feed, and sitemap. In production this must be set correctly.            |
@@ -82,7 +85,11 @@ export default defineAstroPaperConfig({
 | `dir`                | Text direction for `<html dir="...">`. Supports `"ltr"` \| `"rtl"` \| `"auto"`.                                                                |
 | `googleVerification` | Google Search Console verification meta tag value. Optional.                                                                                   |
 
+</ResponsiveTable>
+
 ### `posts` options
+
+<ResponsiveTable>
 
 | Option                | Description                                                                                                                       |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -90,7 +97,11 @@ export default defineAstroPaperConfig({
 | `perIndex`            | Number of posts shown in the Recent section on the home page. Defaults to `4`.                                                    |
 | `scheduledPostMargin` | Posts with a future `pubDatetime` within this window (in ms) are treated as published. Defaults to 15 minutes (`15 * 60 * 1000`). |
 
+</ResponsiveTable>
+
 ### `features` options
+
+<ResponsiveTable>
 
 | Option             | Description                                                                                                                                                                                                                                   |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -100,6 +111,8 @@ export default defineAstroPaperConfig({
 | `showBackButton`   | Show the "Go back" button on post pages. Defaults to `true`.                                                                                                                                                                                  |
 | `editPost`         | An "Edit page" link shown under post titles. Set `enabled: true` and provide the base `url` for your repository's edit URL. Per-post override via `hideEditPost` frontmatter.                                                                 |
 | `search`           | Search provider. `"pagefind"` is the default. Set to `false` to disable search entirely.                                                                                                                                                      |
+
+</ResponsiveTable>
 
 ## Update layout width
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -60,10 +60,6 @@
       th {
         @apply py-1.5;
       }
-
-      code {
-        @apply break-all sm:break-normal;
-      }
     }
 
     code {


### PR DESCRIPTION


## Description

Introduce ResponsiveTable with variant-based styling. Rename docs posts to .mdx, wrap tables in the component, and remove redundant table `code` rules from prose typography.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
