### PR TITLE
fix: duplicate view-transition-name when posts share the same title

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -22,7 +22,7 @@ const { title, description, ...props } = data;
       "focus-visible:no-underline focus-visible:underline-offset-0",
     ]}
   >
-    <Heading transition:name={toTransitionName(title)}>
+    <Heading transition:name={toTransitionName(id)}>
       {title}
     </Heading>
   </a>

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -112,7 +112,7 @@ const ogImage = ogImageUrl
     data-pagefind-body
   >
     <h1
-      style={{ viewTransitionName: toTransitionName(title) }}
+      style={{ viewTransitionName: toTransitionName(post.id) }}
       class="text-accent inline-block text-2xl font-bold sm:text-3xl"
     >
       {title}


### PR DESCRIPTION
## Description

When two posts have the same frontmatter `title`, the listing page (`Card.astro`) generates duplicate `view-transition-name` values for the article cards. The browser's View Transition API requires unique transition names within a page — duplicates cause the API to silently abort, falling back to a hard (non-animated) navigation.

This can be confusing for users: the page transition animation simply disappears without any error message, making it feel like a browser issue.

**Root cause**: `toTransitionName(title)` is called with the post title, which is not guaranteed to be unique. When two posts share a title (e.g., two articles named "Getting Started"), both `<h2>` elements on the listing page end up with the same `view-transition-name`.

**Fix**: Replace `title` with the content collection `id` (the unique file path) when generating transition names. The `id` is inherently unique since no two articles can share the same file path.

This fix applies to both places where transition names are set:
- `src/components/Card.astro` (listing page cards)
- `src/pages/posts/[...slug]/index.astro` (detail page heading)

Both must be updated together — if only one side is changed, the heading won't animate smoothly during navigation.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This is a minimal 2-line fix. An alternative approach would be to use a combination of `id` and `title`, but since `id` already provides uniqueness, adding `title` is redundant.

## Related Issue

No existing issue — found during personal use.
