### PR TITLE
fix: scheduled post filter uses UTC instead of site timezone

### DIFF
--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -1,16 +1,18 @@
 import type { CollectionEntry } from "astro:content";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import config from "@/config";
 
-/**
- * Determines whether a post is eligible to be listed/rendered.
- *
- * - Excludes drafts always
- * - In production, excludes scheduled posts until `pubDatetime` minus the configured margin
- * - In dev, always shows non-draft posts to make authoring easier
- */
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 export function postFilter({ data }: CollectionEntry<"posts">) {
+  const tz = data.timezone ?? config.site.timezone;
+  // Interpret the date in the site's timezone instead of UTC, so that
+  // pubDatetime: 2026-06-28 means "June 28 in Shanghai" not "June 28 UTC".
+  const publishTime = dayjs.utc(data.pubDatetime).tz(tz, true);
   const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - config.posts.scheduledPostMargin;
+    Date.now() > publishTime.valueOf() - config.posts.scheduledPostMargin;
   return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
 }


### PR DESCRIPTION
## Description

The `postFilter` utility compares `pubDatetime` against `Date.now()` to determine whether a scheduled post should be visible. However, `new Date("2026-06-28")` is interpreted as midnight UTC, while the user may be in a different timezone (e.g., Asia/Shanghai, UTC+8).

This means:

- If a user writes a post with `pubDatetime: 2026-06-28` and builds at 3:00 AM China time, the UTC time is still June 27 19:00 — **5 hours before the intended publish time**.
- In dev mode (`import.meta.env.DEV`), the time check is skipped, so the post appears. But in production builds, it's silently filtered out — no error, no warning, just a missing page.
- Only posts with a "today or very recent" `pubDatetime` are affected, making it hard to reproduce and debug.

**Fix**: Use `dayjs.utc(date).tz(tz, true)` to interpret the date in the site's configured timezone rather than UTC. The `true` parameter ("fixed mode") keeps the calendar values unchanged and shifts the underlying UTC instant accordingly, so `2026-06-28` means "June 28 in Shanghai" not "June 28 at Greenwich".

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This only affects users whose timezone offset is positive (east of UTC) and who publish posts on the same day. The existing `Datetime.astro` component already uses `dayjs().tz()` with the site's configured timezone for display — this fix brings `postFilter` in line with that same convention.

## Related Issue

No existing issue — discovered during personal use.
