### PR TITLE
fix: resolve the failure of skip-to-content button

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -193,12 +193,27 @@ const isActive = (path: string) => {
     const skipLink = document.getElementById("skip-to-content");
     if (!skipLink) return;
     skipLink.addEventListener("click", e => {
+      if (
+        e.defaultPrevented ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.button !== 0
+      )
+        return;
       e.preventDefault();
       const target = document.getElementById("main-content");
       if (target) {
         target.setAttribute("tabindex", "-1");
+        target.addEventListener(
+          "blur",
+          () => target.removeAttribute("tabindex"),
+          {
+            once: true,
+          }
+        );
         target.focus();
-        target.scrollIntoView({ behavior: "instant" });
+        target.scrollIntoView({ behavior: "smooth" });
       }
     });
   }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -189,7 +189,23 @@ const isActive = (path: string) => {
     });
   }
 
-  toggleNav();
+  function handleSkipToContent() {
+    const skipLink = document.getElementById("skip-to-content");
+    if (!skipLink) return;
+    skipLink.addEventListener("click", e => {
+      e.preventDefault();
+      const target = document.getElementById("main-content");
+      if (target) {
+        target.setAttribute("tabindex", "-1");
+        target.focus();
+        target.scrollIntoView({ behavior: "instant" });
+      }
+    });
+  }
 
+  toggleNav();
   document.addEventListener("astro:after-swap", toggleNav);
+
+  handleSkipToContent();
+  document.addEventListener("astro:after-swap", handleSkipToContent);
 </script>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -16,7 +16,7 @@ const t = useTranslations(locale);
 
   <main
     id="main-content"
-    class="app-layout flex flex-1 items-center justify-center"
+    class="app-layout my-1 flex flex-1 items-center justify-center"
   >
     <div class="mb-14 flex flex-col items-center justify-center">
       <h1 class="text-accent text-9xl font-bold">404</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const homePath = getRelativeLocaleUrl(locale, "");
     id="main-content"
     data-layout="index"
     data-home-path={homePath}
-    class="app-layout"
+    class="app-layout my-1"
   >
     <section id="hero" class="border-border border-b pt-8 pb-6">
       <h1 class="my-4 inline-block text-4xl font-bold sm:my-8 sm:text-5xl">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,15 +12,13 @@
     scrollbar-color: var(--color-muted) transparent;
   }
   a,
-  button {
+  button,
+  #main-content {
     @apply outline-accent outline-offset-1 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-dashed;
   }
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
-  }
-  #main-content {
-    @apply outline-accent my-1 outline-offset-1 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-dashed;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,9 @@
   [role="button"]:not(:disabled) {
     cursor: pointer;
   }
+  #main-content {
+    @apply outline-accent my-1 outline-offset-1 focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-dashed;
+  }
 }
 
 @utility max-w-app {


### PR DESCRIPTION
## Description

The existing skip-to-content button only used an anchor link to scroll to `#main-content`, but did not move keyboard/screen-reader focus to the main content. This meant that after activation, the focus remained on the skip link itself, failing to actually bypass the header navigation for assistive technology users.

This PR updates `Header.astro` to properly shift focus by adding a click handler for existing skip-to-content button.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (N/A)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
