### PR TITLE
fix: respect markdown table column alignment

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -68,6 +68,21 @@
       th {
         @apply py-1.5;
       }
+
+      th[align="center"],
+      td[align="center"] {
+        text-align: center;
+      }
+
+      th[align="right"],
+      td[align="right"] {
+        text-align: right;
+      }
+
+      th[align="left"],
+      td[align="left"] {
+        text-align: left;
+      }
     }
 
     code {


### PR DESCRIPTION
## Description

Markdown table column alignment (`:---:`, `---:`, `:---`) compiles to the legacy `align` HTML attribute, but AstroPaper's Tailwind Typography table styles never handle that attribute. As a result, centered or right-aligned table columns silently render left-aligned regardless of the alignment markers in the source markdown.

This adds explicit CSS rules for `align="center"`, `align="right"`, and `align="left"` on `th`/`td` so the theme respects the alignment markdown actually produces.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Found this while building a markdown table with a centered column on a site using AstroPaper — the alignment syntax had no visible effect. Traced it to `src/styles/typography.css`: the theme's own table styles don't set `text-align`, but the browser's/Tailwind Typography's baseline styles apparently do, and since the deprecated `align` attribute has the lowest priority in the CSS cascade, it loses to any stylesheet rule regardless of specificity. The fix is a plain CSS addition, no build/config changes needed.

## Related Issue

N/A — no existing issue, small self-contained fix.
