### PR TITLE
fix: prev/next post links point the wrong direction

### DIFF
--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -24,20 +24,22 @@ export async function getStaticPaths() {
     params: { slug: getPostSlug(post.id, post.filePath) },
     props: {
       post,
+      // sortedPosts is newest-first, so "older" (prev) is a higher index
+      // and "newer" (next) is a lower index.
       prevPost:
-        index > 0
-          ? {
-              id: sortedPosts[index - 1].id,
-              title: sortedPosts[index - 1].data.title,
-              filePath: sortedPosts[index - 1].filePath,
-            }
-          : null,
-      nextPost:
         index < sortedPosts.length - 1
           ? {
               id: sortedPosts[index + 1].id,
               title: sortedPosts[index + 1].data.title,
               filePath: sortedPosts[index + 1].filePath,
+            }
+          : null,
+      nextPost:
+        index > 0
+          ? {
+              id: sortedPosts[index - 1].id,
+              title: sortedPosts[index - 1].data.title,
+              filePath: sortedPosts[index - 1].filePath,
             }
           : null,
     },


### PR DESCRIPTION
## Summary

- `getSortedPosts` sorts posts newest-first (index 0 = most recent).
- In `getStaticPaths` for the post page, `prevPost` used `sortedPosts[index - 1]` and `nextPost` used `sortedPosts[index + 1]`.
- Since the array is newest-first, `index - 1` is actually a **newer** post and `index + 1` is an **older** post — the opposite of what "Previous Post" / "Next Post" should mean.
- On any post page, "Previous Post" links to a more recently published post, and "Next Post" links to an older one. Readers expect the reverse: prev = older, next = newer.

This swaps the index math so `prevPost` resolves to the older post (`index + 1`) and `nextPost` resolves to the newer post (`index - 1`), with a comment explaining why the direction is flipped relative to a naive read of the array.

Found this while building a "series" feature on top of AstroPaper for my own blog — the series navigation (sorted oldest-first) didn't have this bug, which is what made the direction mismatch on regular posts obvious by comparison.

## Test plan
- [x] `astro check` — 0 errors, 0 warnings
- [x] `npm run lint` — clean
- [x] `npx prettier --check` — clean
- [ ] Maintainer: verify "Previous Post" / "Next Post" link direction on a couple of real posts after merging
