### PR TITLE
fix: RSS <head> autodiscovery link still has the #647 trailing-slash bug

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,6 @@
 ---
 import { Font } from "astro:assets";
 import { ClientRouter } from "astro:transitions";
-import { getRelativeLocaleUrl } from "astro:i18n";
 import { resolveDefaultOgImagePath } from "@/utils/resolveDefaultOgImagePath";
 import { getAssetPath } from "@/utils/withBase";
 import config from "@/config";
@@ -24,10 +23,7 @@ const {
 } = Astro.props;
 
 const socialImageURL = new URL(ogImage, Astro.site ?? Astro.url);
-const rssHref = getRelativeLocaleUrl(
-  Astro.currentLocale ?? config.site.lang,
-  "rss.xml"
-);
+const rssHref = getAssetPath("rss.xml");
 ---
 
 <!doctype html>


### PR DESCRIPTION
## Description

#647/#649 fixed the trailing-slash bug (`getRelativeLocaleUrl(locale, "rss.xml")` → `/rss.xml/` → 404) for the homepage RSS subscription button, but the same root cause has a second, untouched call site: `src/layouts/Layout.astro`'s `<head>` RSS autodiscovery `<link rel="alternate">`. That link still points at `/rss.xml/`, which 404s since `rss.xml.ts` is a single-file route and never gets a trailing slash.

Found this while auditing a fork of this theme (a real production site) for an unrelated issue — verified against the live theme demo too: view-source on https://astro-paper.pages.dev/ still shows `href="https://astro-paper.pages.dev/rss.xml/"` in `<head>`.

## Fix

Rather than reuse the `import.meta.env.BASE_URL.replace(...)` construction from #649, this uses `getAssetPath()` (`src/utils/withBase.ts`) — the helper `Layout.astro` already imports and already uses for the favicon and `sitemap-index.xml` links a few lines below, solving the exact same "site-root-relative path, base-aware, not locale-prefixed" problem. Also drops the now-unused `getRelativeLocaleUrl` import from this file.

Verified: `pnpm run build` + grepped the built `dist/index.html`, `<head>` now emits `href="https://astro-paper.pages.dev/rss.xml"` (no trailing slash). `pnpm run lint` clean.

## Related Issue

Follow-up to #647 / #649 (second call site of the same bug, not covered by that fix).