### PR TITLE
fix: add spacing below code block filename labels

### DIFF
--- a/src/utils/transformers/fileName.js
+++ b/src/utils/transformers/fileName.js
@@ -40,7 +40,7 @@ export const transformerFileName = ({
     // Add additional margin to code block
     this.addClassToHast(
       node,
-      `mt-8 ${style === "v1" ? "rounded-tl-none" : ""}`
+      `mt-8 pt-6! ${style === "v1" ? "rounded-tl-none" : ""}`
     );
 
     // Add file name to code block


### PR DESCRIPTION
## Description

Code blocks using the `file="..."` metadata render the filename label and copy button very close to the first line of code, making the header area feel a bit cramped.

This change adds extra top padding only to code blocks that contain a filename label. Regular fenced code blocks remain unchanged.

## Screenshots

### Code blocks with a filename

|            | Before                                                                                                                   | After                                                                                                                    |
| ---------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
| Dark mode  | ![Before – dark mode](https://github.com/user-attachments/assets/12e379b2-f992-49f0-9789-507b34984ea0)                  | ![After – dark mode](https://github.com/user-attachments/assets/9d4e578b-3ecf-4bd1-a692-ad1a91f15641)                   |
| Light mode | ![Before – light mode](https://github.com/user-attachments/assets/a2fc1429-6514-428f-96c3-9c4640726d09)                 | ![After – light mode](https://github.com/user-attachments/assets/34d553e8-d838-4821-baab-8c5ae34b2534)                  |

### Code blocks without a filename

Code blocks without `file="..."` remain visually unchanged.

|            | Before                                                                                                          | After                                                                                                         |
| ---------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| Dark mode  | ![Regular block before – dark mode](https://github.com/user-attachments/assets/02a3318c-041f-4d7b-a308-e88e59a48289)  | ![Regular block after – dark mode](https://github.com/user-attachments/assets/7c56b43a-09ec-424e-bdb1-19b466d7625b)  |
| Light mode | ![Regular block before – light mode](https://github.com/user-attachments/assets/35656005-b1a8-4c45-964b-43367292fa43) | ![Regular block after – light mode](https://github.com/user-attachments/assets/2772447d-1d1b-4f78-ae96-ea4166e7ebcd) |

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

I originally applied this adjustment to my own AstroPaper-based blog after starting to use filename labels across several existing posts. I found that the additional spacing provides clearer visual separation between the filename label, the copy button, and the code itself, while making the spacing above the first line more consistent with regular code blocks that do not have a filename.

Since this affects a built-in AstroPaper feature and could improve its default appearance for other users as well, I thought it was worth proposing upstream.

This is intended as a small visual polish suggestion. I have enabled “Allow edits by maintainers”, so please feel free to adjust the spacing or implementation directly on this branch if another approach would fit the theme better.
