### PR TITLE
feat: add series pages for grouping related posts

### DIFF
--- a/astro-paper.config.ts
+++ b/astro-paper.config.ts
@@ -21,6 +21,7 @@ export default defineAstroPaperConfig({
     lightAndDarkMode: true,
     dynamicOgImage: true,
     showArchives: true,
+    showSeries: true,
     showBackButton: true,
     editPost: {
       enabled: true,

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -27,6 +27,7 @@ const decodeSegment = (value: string) => {
 const navLabels: Record<string, string> = {
   posts: t.nav.posts,
   tags: t.nav.tags,
+  series: t.nav.series,
   about: t.nav.about,
   archives: t.nav.archives,
   search: t.nav.search,
@@ -45,6 +46,20 @@ if (breadcrumbList[0] === "posts") {
 // if breadcrumb is Home > Tags > [tag] > [page] <etc>
 // replace [tag] > [page] with localized [tag] (page number)
 if (breadcrumbList[0] === "tags" && !isNaN(Number(breadcrumbList[2]))) {
+  breadcrumbList.splice(
+    1,
+    3,
+    `${decodeSegment(breadcrumbList[1])} ${
+      Number(breadcrumbList[2]) === 1
+        ? ""
+        : `(${t.pagination.page.toLowerCase()} ${breadcrumbList[2]})`
+    }`
+  );
+}
+
+// if breadcrumb is Home > Series > [series] > [page] <etc>
+// replace [series] > [page] with localized [series] (page number)
+if (breadcrumbList[0] === "series" && !isNaN(Number(breadcrumbList[2]))) {
   breadcrumbList.splice(
     1,
     3,

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -90,6 +90,18 @@ const isActive = (path: string) => {
             {t.nav.tags}
           </a>
         </li>
+        {
+          features.showSeries && (
+            <li class="col-span-2">
+              <a
+                href={getRelativeLocaleUrl(locale, "series")}
+                class:list={{ "active-nav": isActive("/series") }}
+              >
+                {t.nav.series}
+              </a>
+            </li>
+          )
+        }
         <li class="col-span-2">
           <a
             href={getRelativeLocaleUrl(locale, "about")}

--- a/src/components/Series.astro
+++ b/src/components/Series.astro
@@ -1,0 +1,42 @@
+---
+import { getRelativeLocaleUrl } from "astro:i18n";
+import { useTranslations } from "@/i18n";
+import Datetime from "./Datetime.astro";
+import config from "@/config";
+
+type Props = {
+  series: string;
+  seriesTitle: string;
+  count: number;
+  complete: boolean;
+  latestPubDatetime: Date;
+  latestPostTitle: string;
+};
+
+const {
+  series,
+  seriesTitle,
+  count,
+  complete,
+  latestPubDatetime,
+  latestPostTitle,
+} = Astro.props;
+
+const locale = Astro.currentLocale ?? config.site.lang;
+const t = useTranslations(locale);
+---
+
+<li class="my-6 w-full">
+  <a
+    href={getRelativeLocaleUrl(locale, `series/${series}/`)}
+    class:list={[
+      "text-accent inline-block text-lg font-medium",
+      "decoration-dashed underline-offset-4 hover:underline",
+      "focus-visible:no-underline focus-visible:underline-offset-0",
+    ]}
+  >
+    {complete && `[${t.pages.seriesComplete}] `}{seriesTitle} ({count})
+  </a>
+  <Datetime pubDatetime={latestPubDatetime} />
+  <p>{latestPostTitle}</p>
+</li>

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ const config: ResolvedAstroPaperConfig = {
     lightAndDarkMode: userConfig.features?.lightAndDarkMode ?? true,
     dynamicOgImage: userConfig.features?.dynamicOgImage ?? true,
     showArchives: userConfig.features?.showArchives ?? true,
+    showSeries: userConfig.features?.showSeries ?? false,
     showBackButton: userConfig.features?.showBackButton ?? true,
     editPost: userConfig.features?.editPost ?? { enabled: false },
     search: userConfig.features?.search ?? "pagefind",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,20 +8,44 @@ export const BLOG_PATH = "src/content/posts";
 const posts = defineCollection({
   loader: glob({ pattern: "**/[^_]*.{md,mdx}", base: `./${BLOG_PATH}` }),
   schema: ({ image }) =>
-    z.object({
-      author: z.string().default(config.site.author),
-      pubDatetime: z.date(),
-      modDatetime: z.date().optional().nullable(),
-      title: z.string(),
-      featured: z.boolean().optional(),
-      draft: z.boolean().optional(),
-      tags: z.array(z.string()).default(["others"]),
-      ogImage: image().or(z.string()).optional(),
-      description: z.string(),
-      canonicalURL: z.string().optional(),
-      hideEditPost: z.boolean().optional(),
-      timezone: z.string().optional(),
-    }),
+    z
+      .object({
+        author: z.string().default(config.site.author),
+        pubDatetime: z.date(),
+        modDatetime: z.date().optional().nullable(),
+        title: z.string(),
+        featured: z.boolean().optional(),
+        draft: z.boolean().optional(),
+        tags: z.array(z.string()).default(["others"]),
+        ogImage: image().or(z.string()).optional(),
+        description: z.string(),
+        canonicalURL: z.string().optional(),
+        hideEditPost: z.boolean().optional(),
+        timezone: z.string().optional(),
+        /** URL slug shared by every post in the series, e.g. "my-series". */
+        series: z.string().optional(),
+        /** Display name for the series, e.g. "My Series". */
+        seriesTitle: z.string().optional(),
+        /** 1-indexed position of this post within the series. */
+        seriesOrder: z.number().optional(),
+        /**
+         * Summary shown on the series' listing page. By convention, set
+         * this on the first post only (later posts can omit it) — the
+         * series page falls back to a generic description otherwise.
+         */
+        seriesDescription: z.string().optional(),
+        /** Marks the series finished. Set on the final post only. */
+        seriesComplete: z.boolean().optional(),
+      })
+      .refine(
+        data =>
+          (data.series === undefined) === (data.seriesTitle === undefined) &&
+          (data.series === undefined) === (data.seriesOrder === undefined),
+        {
+          message:
+            "series, seriesTitle, and seriesOrder must be set together — a post can't have one without the other two.",
+        }
+      ),
 });
 
 const pages = defineCollection({

--- a/src/content/posts/examples/series-example-part-1.md
+++ b/src/content/posts/examples/series-example-part-1.md
@@ -1,0 +1,28 @@
+---
+title: "Series Example: Grouping Related Posts, Part 1"
+author: Sat Naing
+pubDatetime: 2026-09-01T00:00:00Z
+featured: false
+draft: false
+tags:
+  - docs
+description: "EXAMPLE POST: The first post in a demo series, showing the series frontmatter fields (series, seriesTitle, seriesOrder, seriesDescription)."
+series: series-example
+seriesTitle: "Series Example: Grouping Related Posts"
+seriesOrder: 1
+seriesDescription: "A two-part demo of the series feature — set series/seriesTitle/seriesOrder on each post to group them under one series page, with a badge and table of contents on every post in the group."
+---
+
+This is an EXAMPLE POST demonstrating AstroPaper's series feature.
+
+Add these fields to any post's frontmatter to place it in a series:
+
+- `series`: a URL slug shared by every post in the group, e.g. `series-example`
+- `seriesTitle`: the display name shown on the badge, table of contents, and series page
+- `seriesOrder`: this post's 1-indexed position within the series
+- `seriesDescription` (optional): a summary for the series' listing page — set it once, typically on the first post
+- `seriesComplete` (optional): set to `true` on the final post once the series is finished
+
+Once at least one post declares a series, it appears at `/series/`, and every post in it gets a badge under the title (linking back to the series page) plus a full table of contents near the bottom, linking to every part.
+
+Continue to [part 2](/posts/examples/series-example-part-2/) to see the second post in this series.

--- a/src/content/posts/examples/series-example-part-2.md
+++ b/src/content/posts/examples/series-example-part-2.md
@@ -1,0 +1,23 @@
+---
+title: "Series Example: Grouping Related Posts, Part 2"
+author: Sat Naing
+pubDatetime: 2026-09-02T00:00:00Z
+featured: false
+draft: false
+tags:
+  - docs
+description: "EXAMPLE POST: The second and final post in a demo series, showing seriesComplete and the series table of contents."
+series: series-example
+seriesTitle: "Series Example: Grouping Related Posts"
+seriesOrder: 2
+seriesComplete: true
+---
+
+This is the second EXAMPLE POST in the demo series started in [part 1](/posts/examples/series-example-part-1/).
+
+Notice two things this post adds:
+
+- It omits `seriesDescription` — that's only needed once, on the post that should own the series page's summary (part 1, in this case).
+- It sets `seriesComplete: true`, since this is the last part. That marks the whole series `[Complete]` on the `/series/` listing page — it doesn't matter which post in the series carries the flag, only that one of them does.
+
+Scroll to the bottom of this post to see the series table of contents, generated from every post sharing the `series-example` slug.

--- a/src/i18n/lang/en.ts
+++ b/src/i18n/lang/en.ts
@@ -5,6 +5,7 @@ export default {
     home: "Home",
     posts: "Posts",
     tags: "Tags",
+    series: "Series",
     about: "About",
     archives: "Archives",
     search: "Search",
@@ -43,6 +44,13 @@ export default {
 
     tagsTitle: "Tags",
     tagsDesc: "All the tags used in posts.",
+
+    seriesTitle: "Series",
+    seriesDesc: "All the articles in the series",
+    seriesComplete: "Complete",
+
+    seriesListTitle: "Series",
+    seriesListDesc: "All the series I've written.",
 
     postsTitle: "Posts",
     postsDesc: "All the articles I've posted.",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -3,6 +3,7 @@ export interface UIStrings {
     home: string;
     posts: string;
     tags: string;
+    series: string;
     about: string;
     archives: string;
     search: string;
@@ -41,6 +42,13 @@ export interface UIStrings {
 
     tagsTitle: string;
     tagsDesc: string;
+
+    seriesTitle: string;
+    seriesDesc: string;
+    seriesComplete: string;
+
+    seriesListTitle: string;
+    seriesListDesc: string;
 
     postsTitle: string;
     postsDesc: string;

--- a/src/pages/posts/[...slug]/_components/SeriesBadge.astro
+++ b/src/pages/posts/[...slug]/_components/SeriesBadge.astro
@@ -1,0 +1,24 @@
+---
+import { getRelativeLocaleUrl } from "astro:i18n";
+import config from "@/config";
+
+type Props = {
+  seriesTitle: string;
+  seriesSlug: string;
+  currentOrder: number;
+  totalCount: number;
+};
+
+const { seriesTitle, seriesSlug, currentOrder, totalCount } = Astro.props;
+const locale = Astro.currentLocale ?? config.site.lang;
+---
+
+<span class="text-muted-foreground inline-flex items-center gap-1 text-sm">
+  <a
+    href={getRelativeLocaleUrl(locale, `series/${seriesSlug}/`)}
+    class="hover:text-accent underline-offset-4 hover:underline"
+  >
+    {seriesTitle}
+  </a>
+  · {currentOrder}/{totalCount}
+</span>

--- a/src/pages/posts/[...slug]/_components/SeriesToc.astro
+++ b/src/pages/posts/[...slug]/_components/SeriesToc.astro
@@ -1,0 +1,42 @@
+---
+import { getPostUrl } from "@/utils/getPostPaths";
+import config from "@/config";
+
+type Props = {
+  seriesTitle: string;
+  entries: {
+    id: string;
+    title: string;
+    filePath: string | undefined;
+    seriesOrder: number;
+    isCurrent: boolean;
+  }[];
+};
+
+const { seriesTitle, entries } = Astro.props;
+const locale = Astro.currentLocale ?? config.site.lang;
+---
+
+<div data-pagefind-ignore class="my-8">
+  <h2 class="text-lg font-semibold">{seriesTitle}</h2>
+  <ol class="mt-3 flex flex-col gap-2">
+    {
+      entries.map(entry => (
+        <li>
+          {entry.isCurrent ? (
+            <span class="text-accent font-medium" aria-current="page">
+              {entry.seriesOrder}. {entry.title}
+            </span>
+          ) : (
+            <a
+              href={getPostUrl(entry.id, entry.filePath, locale)}
+              class="hover:text-accent underline-offset-4 hover:underline"
+            >
+              {entry.seriesOrder}. {entry.title}
+            </a>
+          )}
+        </li>
+      ))
+    }
+  </ol>
+</div>

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -7,6 +7,7 @@ import Datetime from "@/components/Datetime.astro";
 import Tag from "@/components/Tag.astro";
 import { getPostSlug, getPostUrl } from "@/utils/getPostPaths";
 import { getSortedPosts } from "@/utils/getSortedPosts";
+import { getSortedSeriesPosts } from "@/utils/getSortedSeriesPosts";
 import { slugifyStr } from "@/utils/slugify";
 import { toTransitionName } from "@/utils/toTransitionName";
 import EditPost from "./_components/EditPost.astro";
@@ -14,36 +15,60 @@ import ShareLinks from "./_components/ShareLinks.astro";
 import BackButton from "./_components/BackButton.astro";
 import BackToTopButton from "./_components/BackToTopButton.astro";
 import AdjacentPostNav from "./_components/AdjacentPostNav.astro";
+import SeriesBadge from "./_components/SeriesBadge.astro";
+import SeriesToc from "./_components/SeriesToc.astro";
 import config from "@/config";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
   const sortedPosts = getSortedPosts(posts);
 
-  return sortedPosts.map((post, index) => ({
-    params: { slug: getPostSlug(post.id, post.filePath) },
-    props: {
-      post,
-      // sortedPosts is newest-first, so "older" (prev) is a higher index
-      // and "newer" (next) is a lower index.
-      prevPost:
-        index < sortedPosts.length - 1
-          ? {
-              id: sortedPosts[index + 1].id,
-              title: sortedPosts[index + 1].data.title,
-              filePath: sortedPosts[index + 1].filePath,
-            }
-          : null,
-      nextPost:
-        index > 0
-          ? {
-              id: sortedPosts[index - 1].id,
-              title: sortedPosts[index - 1].data.title,
-              filePath: sortedPosts[index - 1].filePath,
-            }
-          : null,
-    },
-  }));
+  return sortedPosts.map((post, index) => {
+    const seriesSlug = post.data.series;
+    const seriesInfo: SeriesInfo =
+      seriesSlug !== undefined
+        ? (() => {
+            const seriesPosts = getSortedSeriesPosts(posts, seriesSlug);
+            return {
+              seriesTitle: post.data.seriesTitle as string,
+              seriesSlug,
+              entries: seriesPosts.map(p => ({
+                id: p.id,
+                title: p.data.title,
+                filePath: p.filePath,
+                seriesOrder: p.data.seriesOrder as number,
+                isCurrent: p.id === post.id,
+              })),
+            };
+          })()
+        : null;
+
+    return {
+      params: { slug: getPostSlug(post.id, post.filePath) },
+      props: {
+        post,
+        // sortedPosts is newest-first, so "older" (prev) is a higher index
+        // and "newer" (next) is a lower index.
+        prevPost:
+          index < sortedPosts.length - 1
+            ? {
+                id: sortedPosts[index + 1].id,
+                title: sortedPosts[index + 1].data.title,
+                filePath: sortedPosts[index + 1].filePath,
+              }
+            : null,
+        nextPost:
+          index > 0
+            ? {
+                id: sortedPosts[index - 1].id,
+                title: sortedPosts[index - 1].data.title,
+                filePath: sortedPosts[index - 1].filePath,
+              }
+            : null,
+        seriesInfo,
+      },
+    };
+  });
 }
 
 type AdjacentPost = {
@@ -52,13 +77,26 @@ type AdjacentPost = {
   filePath: string | undefined;
 } | null;
 
+type SeriesInfo = {
+  seriesTitle: string;
+  seriesSlug: string;
+  entries: {
+    id: string;
+    title: string;
+    filePath: string | undefined;
+    seriesOrder: number;
+    isCurrent: boolean;
+  }[];
+} | null;
+
 type Props = {
   post: CollectionEntry<"posts">;
   prevPost: AdjacentPost;
   nextPost: AdjacentPost;
+  seriesInfo: SeriesInfo;
 };
 
-const { post, prevPost, nextPost } = Astro.props;
+const { post, prevPost, nextPost, seriesInfo } = Astro.props;
 const locale = Astro.currentLocale ?? config.site.lang;
 
 const {
@@ -134,6 +172,19 @@ const ogImage = ogImageUrl
       <EditPost {hideEditPost} {post} class="max-sm:hidden" />
     </div>
 
+    {
+      seriesInfo && (
+        <SeriesBadge
+          seriesTitle={seriesInfo.seriesTitle}
+          seriesSlug={seriesInfo.seriesSlug}
+          currentOrder={
+            seriesInfo.entries.find(e => e.isCurrent)?.seriesOrder ?? 1
+          }
+          totalCount={seriesInfo.entries.length}
+        />
+      )
+    }
+
     <article
       id="article"
       class:list={[
@@ -158,6 +209,15 @@ const ogImage = ogImageUrl
     <ShareLinks />
 
     <hr class="my-8 border-dashed" />
+
+    {
+      seriesInfo && (
+        <SeriesToc
+          seriesTitle={seriesInfo.seriesTitle}
+          entries={seriesInfo.entries}
+        />
+      )
+    }
 
     <AdjacentPostNav {prevPost} {nextPost} />
   </main>

--- a/src/pages/series/[series]/[...page].astro
+++ b/src/pages/series/[series]/[...page].astro
@@ -1,0 +1,59 @@
+---
+import { getCollection } from "astro:content";
+import type { GetStaticPathsOptions } from "astro";
+import Layout from "@/layouts/Layout.astro";
+import Header from "@/components/Header.astro";
+import Main from "@/components/Main.astro";
+import Breadcrumb from "@/components/Breadcrumb.astro";
+import Card from "@/components/Card.astro";
+import Footer from "@/components/Footer.astro";
+import Pagination from "@/components/Pagination.astro";
+import { getSeries } from "@/utils/getSeries";
+import { getSortedSeriesPosts } from "@/utils/getSortedSeriesPosts";
+import { useTranslations } from "@/i18n";
+import config from "@/config";
+
+export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
+  const posts = await getCollection("posts", ({ data }) => !data.draft);
+  const series = getSeries(posts);
+
+  return series.flatMap(({ series: seriesSlug, seriesTitle, complete }) => {
+    const seriesPosts = getSortedSeriesPosts(posts, seriesSlug);
+    // By convention, seriesDescription is written once on the first post
+    // (seriesPosts[0] after sorting ascending) — a summary of the series as
+    // a whole, not that post's own excerpt. Falls back to generic text.
+    const seriesDescription = seriesPosts[0]?.data.seriesDescription;
+
+    return paginate(seriesPosts, {
+      params: { series: seriesSlug },
+      props: { seriesTitle, complete, seriesDescription },
+      pageSize: config.posts.perPage,
+    });
+  });
+}
+
+const { page, seriesTitle, complete, seriesDescription } = Astro.props;
+
+const locale = Astro.currentLocale ?? config.site.lang;
+const t = useTranslations(locale);
+
+const completePrefix = complete ? `[${t.pages.seriesComplete}] ` : "";
+const pageDesc = seriesDescription ?? `${t.pages.seriesDesc} "${seriesTitle}".`;
+const pageTitle = `${completePrefix}${t.pages.seriesTitle}: ${seriesTitle}`;
+---
+
+<Layout title={`${pageTitle} | ${config.site.title}`} description={pageDesc}>
+  <Header />
+
+  <Breadcrumb />
+
+  <Main pageTitle={pageTitle} pageDesc={pageDesc}>
+    <ul>
+      {page.data.map(data => <Card {...data} />)}
+    </ul>
+  </Main>
+
+  <Pagination {page} />
+
+  <Footer noMarginTop={page.lastPage > 1} />
+</Layout>

--- a/src/pages/series/index.astro
+++ b/src/pages/series/index.astro
@@ -1,0 +1,35 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@/layouts/Layout.astro";
+import Header from "@/components/Header.astro";
+import Breadcrumb from "@/components/Breadcrumb.astro";
+import Main from "@/components/Main.astro";
+import Footer from "@/components/Footer.astro";
+import Series from "@/components/Series.astro";
+import { getSeries } from "@/utils/getSeries";
+import { useTranslations } from "@/i18n";
+import config from "@/config";
+
+const posts = await getCollection("posts", ({ data }) => !data.draft);
+const series = getSeries(posts);
+
+const locale = Astro.currentLocale ?? config.site.lang;
+const t = useTranslations(locale);
+---
+
+<Layout
+  title={`${t.pages.seriesListTitle} | ${config.site.title}`}
+  description={t.pages.seriesListDesc}
+>
+  <Header />
+
+  <Breadcrumb />
+
+  <Main pageTitle={t.pages.seriesListTitle} pageDesc={t.pages.seriesListDesc}>
+    <ul class="flex flex-wrap gap-6">
+      {series.map(s => <Series {...s} />)}
+    </ul>
+  </Main>
+
+  <Footer />
+</Layout>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,6 +44,12 @@ interface FeaturesConfig {
   dynamicOgImage?: boolean;
   /** Show the /archives page and link it in nav. Defaults to true. */
   showArchives?: boolean;
+  /**
+   * Show the /series page and link it in nav. Defaults to false — most
+   * sites don't group posts into series, so this stays opt-in even when
+   * posts use the `series`/`seriesTitle`/`seriesOrder` frontmatter.
+   */
+  showSeries?: boolean;
   /** Show back button on post detail pages. Defaults to true. */
   showBackButton?: boolean;
   /** "Edit page" link shown on post detail pages. */

--- a/src/utils/getSeries.ts
+++ b/src/utils/getSeries.ts
@@ -1,0 +1,70 @@
+import type { CollectionEntry } from "astro:content";
+import { postFilter } from "./postFilter";
+
+type Series = {
+  series: string;
+  seriesTitle: string;
+  count: number;
+  complete: boolean;
+  latestPubDatetime: Date;
+  latestPostTitle: string;
+};
+
+/**
+ * Builds a de-duplicated list of series from posts, sorted by each series'
+ * most recent post (pubDatetime) descending.
+ *
+ * - Drafts and scheduled posts are excluded via `postFilter()`
+ * - A post only counts as part of a series when `series`, `seriesTitle`, and
+ *   `seriesOrder` are all present — the schema's `.refine()` already
+ *   guarantees they're set together, but a post can still omit all three.
+ * - A series is `complete` if ANY of its posts has `seriesComplete: true` —
+ *   by convention this is set on the final post only, but the check itself
+ *   doesn't care which post carries it.
+ */
+export function getSeries(posts: CollectionEntry<"posts">[]) {
+  const seriesPosts = posts
+    .filter(postFilter)
+    .filter(
+      ({ data }) =>
+        data.series !== undefined &&
+        data.seriesTitle !== undefined &&
+        data.seriesOrder !== undefined
+    );
+
+  const bySeriesSlug = new Map<string, CollectionEntry<"posts">[]>();
+  for (const post of seriesPosts) {
+    const slug = post.data.series as string;
+    const existing = bySeriesSlug.get(slug) ?? [];
+    existing.push(post);
+    bySeriesSlug.set(slug, existing);
+  }
+
+  const latestPost = (slug: string) =>
+    (bySeriesSlug.get(slug) ?? []).reduce((latest, post) =>
+      new Date(post.data.pubDatetime).getTime() >
+      new Date(latest.data.pubDatetime).getTime()
+        ? post
+        : latest
+    );
+
+  const series: Series[] = Array.from(bySeriesSlug.entries()).map(
+    ([slug, seriesPostList]) => {
+      const latest = latestPost(slug);
+      return {
+        series: slug,
+        seriesTitle: seriesPostList[0].data.seriesTitle as string,
+        count: seriesPostList.length,
+        complete: seriesPostList.some(
+          post => post.data.seriesComplete === true
+        ),
+        latestPubDatetime: new Date(latest.data.pubDatetime),
+        latestPostTitle: latest.data.title,
+      };
+    }
+  );
+
+  return series.sort(
+    (a, b) => b.latestPubDatetime.getTime() - a.latestPubDatetime.getTime()
+  );
+}

--- a/src/utils/getSortedSeriesPosts.ts
+++ b/src/utils/getSortedSeriesPosts.ts
@@ -1,0 +1,22 @@
+import type { CollectionEntry } from "astro:content";
+import { postFilter } from "./postFilter";
+
+/**
+ * Returns the posts belonging to one series, sorted by `seriesOrder`
+ * ascending (part 1 first). Posts missing `series` or `seriesOrder` are
+ * excluded. A duplicate `seriesOrder` value doesn't error — `Array.sort` is
+ * stable, so ties keep their original relative order.
+ */
+export function getSortedSeriesPosts(
+  posts: CollectionEntry<"posts">[],
+  seriesSlug: string
+) {
+  return posts
+    .filter(postFilter)
+    .filter(
+      ({ data }) => data.series === seriesSlug && data.seriesOrder !== undefined
+    )
+    .sort(
+      (a, b) => (a.data.seriesOrder as number) - (b.data.seriesOrder as number)
+    );
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in way to group related posts into a series, for blogs that publish multi-part write-ups.
- New frontmatter fields on `posts`: `series`, `seriesTitle`, `seriesOrder`, `seriesDescription` (optional), `seriesComplete` (optional). A zod `.refine()` requires `series`/`seriesTitle`/`seriesOrder` to be set together.
- New `/series` listing page and `/series/[series]/[...page]` paginated page, mirroring the existing `/tags` pattern (same `Card`/`Pagination` components, same page-size config).
- Post detail pages gain a small badge under the title (series name + position, e.g. "My Series · 2/4" — only the series name is a link) and a full table of contents near the bottom, both only rendered when the post belongs to a series.
- Gated behind `features.showSeries` (defaults to `false`), so existing sites see zero change until they opt in. This repo's own `astro-paper.config.ts` turns it on, and two example posts (`src/content/posts/examples/series-example-part-*.md`) demonstrate it end to end.
- `prevPost`/`nextPost` adjacent-post navigation is untouched — still walks all posts chronologically regardless of series membership. Wiring series-aware prev/next felt like a separate decision (does "next" mean next in series, or next chronologically?) that didn't need bundling into this PR.

## Test plan
- [x] `astro check` — 0 errors
- [x] `eslint .` — clean
- [x] `prettier --check .` — clean
- [x] `astro build` — succeeds, generates `/series/`, `/series/series-example/`, and the two example posts
- [x] Verified rendered HTML on a local dev server: series index card, series page listing, post badge (title-only link), and series TOC all render as expected