### PR TITLE
[fix] make build script work on Windows (replace cp with a Node script)

### DIFF
--- a/copy-pagefind.mjs
+++ b/copy-pagefind.mjs
@@ -1,0 +1,7 @@
+// Cross-platform stand-in for the previous `cp -r dist/pagefind public/`
+// build step: cmd.exe, the shell npm/pnpm runs scripts with on Windows,
+// has no `cp`, so the full build used to fail there. Keeping the index in
+// public/ lets `astro dev` and subsequent builds serve it.
+import { cpSync } from "node:fs";
+
+cpSync("dist/pagefind", "public/pagefind", { recursive: true, force: true });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/",
+    "build": "astro check && astro build && pagefind --site dist && node copy-pagefind.mjs",
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",


### PR DESCRIPTION
## Problem

The build script's last step uses `cp -r dist/pagefind public/`. On Windows, npm/pnpm run package scripts through cmd.exe, which has no `cp` (a POSIX utility), so the full build always fails right after pagefind runs — see #680.

## Fix

Replace the `cp` step with a small cross-platform Node script (`node:fs` `cpSync`):

- `copy-pagefind.mjs` — copies `dist/pagefind` into `public/pagefind`
- `package.json` build script now ends with `node copy-pagefind.mjs`

## Verification

- Windows + Node 24: `pnpm build` completes (astro check → astro build → pagefind → copy)
- Linux/macOS behavior unchanged

Fixes #680